### PR TITLE
Implement IPMI enable and disable functions.

### DIFF
--- a/imcsdk/apis/admin/ipmi.py
+++ b/imcsdk/apis/admin/ipmi.py
@@ -1,0 +1,78 @@
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+This module implements all the communication services
+"""
+from imcsdk.mometa.comm.CommIpmiLan import CommIpmiLan, CommIpmiLanConsts
+
+
+def enable_ipmi(handle, priv=CommIpmiLanConsts.PRIV_ADMIN, key='0'*40):
+    """
+    Enable IPMI over LAN.
+
+    Args:
+        handle (ImcHandle)
+        priv (string): Optional privilege level: 'admin', 'user', 'read-only'
+        key (string): Optional encryption key as hexadecimal string
+
+    Returns:
+        True
+
+    Raises:
+        ValueError if privilege or key are invalid
+
+    Example:
+        if enable_ipmi(handle):
+            print "IPMI Enabled"
+    """
+    # Verify priv string is valid privilege level
+    if priv is not CommIpmiLanConsts.PRIV_ADMIN and \
+       priv is not CommIpmiLanConsts.PRIV_USER and \
+       priv is not CommIpmiLanConsts.PRIV_READ_ONLY:
+        raise ValueError('{0}: ERROR: invalid privilege level: ' +
+                         '"{1}"'.format(handle.ip, priv))
+
+    # Verify key is a hex number
+    try:
+        hex(int(key, 16))[2:]
+    except ValueError:
+        raise ValueError('{0}: ERROR: Encryption key is not hex number: ' +
+                         '"{1}"'.format(handle.ip, key))
+
+    # Create enabled IPMI object
+    ipmi_mo = CommIpmiLan(parent_mo_or_dn="sys/svc-ext",
+                          admin_state="enabled", priv=priv, key=key)
+
+    # Configure IPMI object on CIMC
+    handle.set_mo(ipmi_mo)
+    return True
+
+
+def disable_ipmi(handle):
+    """
+    Disable IPMI over LAN.
+    Args:
+        handle (ImcHandle)
+
+    Returns:
+        True
+
+    """
+    # Create disabled IPMI object
+    ipmi_mo = CommIpmiLan(parent_mo_or_dn="sys/svc-ext",
+                          admin_state="disabled")
+    # Configure IPMI object on CIMC
+    handle.set_mo(ipmi_mo)
+    return True

--- a/tests/unit_tests/test_ipmi.py
+++ b/tests/unit_tests/test_ipmi.py
@@ -1,0 +1,81 @@
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import patch
+from nose.tools import assert_raises
+from imcsdk.imchandle import ImcHandle
+from imcsdk.mometa.comm.CommIpmiLan import CommIpmiLanConsts
+from imcsdk.apis.admin.ipmi import disable_ipmi, enable_ipmi
+
+
+@patch.object(ImcHandle, 'set_mo')
+@patch.object(ImcHandle, 'login')
+def test_valid_enable_ipmi(login_mock, set_mo_mock):
+    # Patch ImcHandle.login to create a Faux ImcHandle object w/o real CIMC
+    # Patch ImcHandle.set_mo to simulate CIMC interaction w/o real CIMC
+    login_mock.return_value = True
+    set_mo_mock.return_value = True
+    test_cimc = ImcHandle(ip='169.254.1.1',
+                          username='admin',
+                          password='right')
+
+    # Scenario: Enable IPMI default values
+    assert enable_ipmi(test_cimc) is True
+    # Assert values of the object passed to add_mo()
+    test_ipmi_mo = set_mo_mock.call_args[0][0]
+    assert test_ipmi_mo.admin_state == "enabled"
+    assert test_ipmi_mo.priv == CommIpmiLanConsts.PRIV_ADMIN
+    assert test_ipmi_mo.key == '0'*40
+
+    # Scenario: Enable IPMI custom priv and key
+    assert enable_ipmi(test_cimc, priv="user", key='1'*40) is True
+    test_ipmi_mo = set_mo_mock.call_args[0][0]
+    assert test_ipmi_mo.admin_state == "enabled"
+    assert test_ipmi_mo.priv == "user"
+    assert test_ipmi_mo.key == '1'*40
+
+
+@patch.object(ImcHandle, 'set_mo')
+@patch.object(ImcHandle, 'login')
+def test_invalid_enable_ipmi(login_mock, set_mo_mock):
+    # Patch ImcHandle.login to create a Faux ImcHandle object w/o real CIMC
+    # Patch ImcHandle.set_mo to simulate CIMC interaction w/o real CIMC
+    login_mock.return_value = True
+    set_mo_mock.return_value = True
+    test_cimc = ImcHandle(ip='169.254.1.1',
+                          username='admin',
+                          password='right')
+
+    # Scenario: Invalid priv value
+    assert_raises(ValueError, enable_ipmi, test_cimc, priv="Wrong")
+
+    # Scenario: Invalid key
+    assert_raises(ValueError, enable_ipmi, test_cimc, key='bacon')
+
+
+@patch.object(ImcHandle, 'set_mo')
+@patch.object(ImcHandle, 'login')
+def test_valid_disable_ipmi(login_mock, set_mo_mock):
+    # Patch ImcHandle.login to create a Faux ImcHandle object w/o real CIMC
+    # Patch ImcHandle.set_mo to simulate CIMC interaction w/o real CIMC
+    login_mock.return_value = True
+    set_mo_mock.return_value = True
+    test_cimc = ImcHandle(ip='169.254.1.1',
+                          username='admin',
+                          password='right')
+
+    # Scenario: Enable IPMI default values
+    assert disable_ipmi(test_cimc) is True
+    # Assert values of the object passed to add_mo()
+    test_ipmi_mo = set_mo_mock.call_args[0][0]
+    assert test_ipmi_mo.admin_state == "disabled"


### PR DESCRIPTION
This commit adds the apis/admin/communication_services.py
module with functions to both enable and disable IPMI.

Signed-off-by: Britt Houser bhouser@cisco.com
