### PR TITLE
avoid taking id of disabled user

### DIFF
--- a/imcsdk/apis/admin/user.py
+++ b/imcsdk/apis/admin/user.py
@@ -98,7 +98,7 @@ def create_local_user(handle, username, password, privilege="read-only"):
     inactive_users = []
 
     for user in aaa_users:
-        if user.account_status == AaaUserConsts.ACCOUNT_STATUS_INACTIVE:
+        if user.account_status == AaaUserConsts.ACCOUNT_STATUS_INACTIVE and not user.name:
             inactive_users.append(user)
 
     if len(inactive_users) is 0:


### PR DESCRIPTION
If there is a scenario, where multiple users are available and some of them are disabled, the method currently tries to create a new user on the id slot of the first disabled user. Adding this prohibits this behaviour, if there is already a user sitting on this slot.