### PR TITLE
fix version checks

### DIFF
--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -108,11 +108,14 @@ class ImcVersion(object):
             return 1
 
         if self.__major != version.major:
-            return ord(self.__major) - ord(version.major)
+            func = (ord, int)[self.__major.isdigit() and version.major.isdigit()]
+            return func(self.__major) - func(version.major)
         if self.__minor != version.minor:
-            return ord(self.__minor) - ord(version.major)
+            func = (ord, int)[self.__minor.isdigit() and version.minor.isdigit()]
+            return func(self.__minor) - func(version.major)
         if self.__mr != version.mr:
-            return ord(self.__mr) - ord(version.mr)
+            func = (ord, int)[self.__mr.isdigit() and version.mr.isdigit()]
+            return func(self.__mr) - func(version.mr)
         return ord(self.__patch) - ord(version.patch)
 
     def __gt__(self, version):


### PR DESCRIPTION
- Imc versions will always be of the format `<major>.<minor>(<mr><patch>)` and major/minor/mr fields are always expected to be integers.
- While comparing versions, we need to account for multi-byte versions of these fields where `ord()`  will fail.
- Changing these calls to `int()` to account for this change.

Signed-off-by: Swapnil Wagh <waghswapnil@gmail.com>