### PR TITLE
Support for TLS 1.1/1.2 and fallback support to TLSv1 for older servers

### DIFF
--- a/imcsdk/imcdriver.py
+++ b/imcsdk/imcdriver.py
@@ -85,6 +85,55 @@ class TLS1Connection(httplib.HTTPSConnection):
                                     ssl_version=ssl.PROTOCOL_TLSv1)
 
 
+class TLSHandler(urllib2.HTTPSHandler):
+    """Like HTTPSHandler but more specific"""
+
+    def __init__(self):
+        urllib2.HTTPSHandler.__init__(self)
+
+    def https_open(self, req):
+        return self.do_open(TLSConnection, req)
+
+
+class TLSConnection(httplib.HTTPSConnection):
+    """Like HTTPSConnection but more specific"""
+
+    def __init__(self, host, **kwargs):
+        httplib.HTTPSConnection.__init__(self, host, **kwargs)
+
+    def connect(self):
+        """Overrides HTTPSConnection.connect to specify TLS version"""
+        # Standard implementation from HTTPSConnection, which is not
+        # designed for extension, unfortunately
+        if sys.version_info >= (2, 7):
+            sock = socket.create_connection((self.host, self.port),
+                                            self.timeout, self.source_address)
+        elif sys.version_info >= (2, 6):
+            sock = socket.create_connection((self.host, self.port),
+                                            self.timeout)
+        else:
+            sock = socket.create_connection((self.host, self.port))
+
+        if getattr(self, '_tunnel_host', None):
+            self.sock = sock
+            self._tunnel()
+
+        if sys.version_info >= (2, 7, 9):
+            # Since python 2.7.9, tls 1.1 and 1.2 are supported via
+            # SSLContext
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+            ssl_context.options |= ssl.OP_NO_SSLv2
+            ssl_context.options |= ssl.OP_NO_SSLv3
+            if self.key_file and self.cert_file:
+                ssl_context.load_cert_chain(keyfile=self.key_file,
+                                            certfile=self.cert_file)
+            self.sock = ssl_context.wrap_socket(sock)
+        else:
+            # This is the only difference; default wrap_socket uses SSLv23
+            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
+                                        ssl_version=ssl.PROTOCOL_TLSv1)
+
+
 class ImcDriver(object):
     """
     This class is responsible to create http and https connection using urllib
@@ -103,12 +152,18 @@ class ImcDriver(object):
         self.__headers = {}
         self.__handlers = self.__get_handlers()
 
-    def __get_handlers(self):
+    def update_handlers(self, tls_proto=None):
+        self.__handlers = self.__get_handlers(tls_proto)
+
+    def __get_handlers(self, tls_proto=None):
         """
         Internal method to handle redirection and use TLS protocol.
         """
 
-        handlers = [SmartRedirectHandler, TLS1Handler]
+        # tls_handler implements a fallback mechanism for servers that
+        # do not support TLS 1.1/1.2
+        tls_handler = (TLSHandler, TLS1Handler)[tls_proto == "tlsv1"]
+        handlers = [SmartRedirectHandler, tls_handler]
         if self.__proxy:
             proxy_handler = urllib2.ProxyHandler(
                 {'http': self.__proxy, 'https': self.__proxy})
@@ -205,7 +260,16 @@ class ImcDriver(object):
                 log.debug('%s ====> %s' % (uri, data))
 
             opener = urllib2.build_opener(*self.__handlers)
-            response = opener.open(request, timeout=timeout)
+            try:
+                response = opener.open(request, timeout=timeout)
+            except Exception as e:
+                if "SSL".lower() not in str(e).lower():
+                    raise
+
+                # Fallback to TLSv1 for this server
+                self.update_handlers(tls_proto="tlsv1")
+                opener = urllib2.build_opener(*self.__handlers)
+                response = opener.open(request, timeout=timeout)
 
             if type(response) is list:
                 if len(response) == 2 and \


### PR DESCRIPTION
Requirement was to support TLSv1, 1.1, 1.2
Previously we were using only TLSv1. 

New code, creates an sslcontext with ssl.PROTOCOL_SSLv23 which supports SSLv3, SSLv2v3, TLSv1, TLSv1.1, TLSv1.2. We disable SSLv2, SSLv3 from this list.

Openssl client hits a tlv parsing issue with some older servers when using TLSv1.2 handshake. This happens because of the TLV header length padding that had changed between TLS versions.
These servers would need TLSv1 to connect. Hence, a fallback mechanism is implemented if connection via TLSv1.1/TLSv1.2 fails.

Signed-off-by: Vikrant Balyan <vijayvikrant84@gmail.com>