### PR TITLE
APIs to verify if a specified boot order already exists

### DIFF
--- a/imcsdk/apis/server/adaptor.py
+++ b/imcsdk/apis/server/adaptor.py
@@ -21,10 +21,6 @@ from imcsdk.imccoreutils import get_server_dn
 from imcsdk.imcexception import ImcOperationError
 
 
-def _is_valid_arg(param, kwargs):
-    return kwargs.get(param) is not None
-
-
 def _get_adaptor(handle, adaptor_slot, server_id=1, **kwargs):
 
     server_dn = get_server_dn(handle, server_id)

--- a/imcsdk/apis/server/serveractions.py
+++ b/imcsdk/apis/server/serveractions.py
@@ -24,17 +24,8 @@ from imcsdk.mometa.equipment.EquipmentLocatorLed \
     import EquipmentLocatorLed, EquipmentLocatorLedConsts
 from imcsdk.mometa.equipment.EquipmentChassisLocatorLed \
     import EquipmentChassisLocatorLed, EquipmentChassisLocatorLedConsts
-from imcsdk.imccoreutils import get_server_dn, IMC_PLATFORM
-
-
-def _is_valid_arg(param, kwargs):
-    return kwargs.get(param) is not None
-
-
-def _set_server_dn(handle, kwargs):
-    server_id = str(kwargs.get("server_id", "1"))
-    server_dn = get_server_dn(handle, server_id)
-    return server_dn
+from imcsdk.imccoreutils import get_server_dn, IMC_PLATFORM, _set_server_dn, \
+        _is_valid_arg
 
 
 def _set_power_state(handle, server_dn, state):

--- a/imcsdk/imccoreutils.py
+++ b/imcsdk/imccoreutils.py
@@ -865,6 +865,15 @@ def get_dn_prefix_for_platform(handle):
         return ""
 
 
+def _set_server_dn(handle, kwargs):
+    server_id = kwargs.get("server_id", "1")
+    return get_server_dn(handle, str(server_id))
+
+
+def _is_valid_arg(param, kwargs):
+    return kwargs.get(param) is not None
+
+
 def get_handle_from_cookie(cookie):
 
     for handle in global_handles:

--- a/imcsdk/imcmo.py
+++ b/imcsdk/imcmo.py
@@ -196,6 +196,27 @@ class ManagedObject(ImcBase):
                 self._dirty_mask |= mask
         object.__setattr__(self, name, value)
 
+    def check_prop_match(self, **kwargs):
+        for prop_name in kwargs:
+            if not imccoreutils.prop_exists(self, prop_name):
+                raise ValueError("Invalid Property Name Exception - "
+                                 "Class [%s]: Prop <%s> "
+                                 % (self.__class__.__name__, prop_name))
+
+            if kwargs[prop_name] != getattr(self, prop_name):
+                return False
+        return True
+
+    def set_prop_multiple(self, **kwargs):
+        for prop_name in kwargs:
+            if imccoreutils.prop_exists(prop_name):
+                self.__set_prop(prop_name, kwargs[prop_name])
+            else:
+                ImcWarning("Invalid Property Name for "
+                           "Class [%s]: Prop <%s>, setting it forcefully"
+                           % (self.__class__.__name__, prop_name))
+                self.__set_prop(prop_name, kwargs[prop_name], forced=True)
+
     def __str__(self):
         """
         Method to return string representation of a managed object.

--- a/imcsdk/utils/imcbackup.py
+++ b/imcsdk/utils/imcbackup.py
@@ -19,10 +19,6 @@ import time
 from ..imcexception import ImcValidationException
 
 
-def _is_valid_arg(param, kwargs):
-    return kwargs.get(param) is not None
-
-
 def backup_imc(handle, remote_host, remote_file, protocol, username, password,
                passphrase, timeout_in_sec=600, entity="CMC", **kwargs):
     """
@@ -39,7 +35,7 @@ def backup_imc(handle, remote_host, remote_file, protocol, username, password,
         timeout_in_sec (number) : time in seconds for which method waits
                               for the backUp file to generate before it exits.
         entity (str): For C3260 platforms:
-                      "CMC" for backup of chassis related configuration and state  
+                      "CMC" for backup of chassis related configuration and state
                       "CIMC1" for backup of server-1 related configuration and state
                       "CIMC2" for backup of server-2 related configuration and state
         kwargs : key=value paired arguments

--- a/imcsdk/utils/imctechsupport.py
+++ b/imcsdk/utils/imctechsupport.py
@@ -20,10 +20,6 @@ from ..imcexception import ImcValidationException, ImcWarning
 from ..imccoreutils import IMC_PLATFORM
 
 
-def _is_valid_arg(param, kwargs):
-    return kwargs.get(param) is not None
-
-
 def get_imc_tech_support(handle, remote_host, remote_file, protocol, username,
                          password, timeout_in_sec=600,
                          component="all", **kwargs):
@@ -41,7 +37,7 @@ def get_imc_tech_support(handle, remote_host, remote_file, protocol, username,
         timeout_in_sec (number) : time in seconds for which method waits
                               for the backUp file to generate before it exits.
         component (str) : For C3260 platforms
-                          "all" for tech-support of all components 
+                          "all" for tech-support of all components
                           "cmc1" for tech-support of chassis related components on chassis controller-1
                           "cmc2" for tech-support of chassis related components on chassis controller-2
                           "cimc1" for tech-support of server related components on server-1


### PR DESCRIPTION
1. added API to verify is a specified boot_precision order already exists
2. revamped the boot order APIs
3. added tests for `boot_order_precision_exists`
4. moved some common code to imccoreutils

RELEASE_NOTE:
     API changes -> boot_devices is changed from list of tuples to list of dictionaries

Signed-off-by: Vikrant Balyan <vijayvikrant84@gmail.com>