### PR TITLE
improving the boot order apis

### DIFF
--- a/imcsdk/apis/server/bios.py
+++ b/imcsdk/apis/server/bios.py
@@ -120,6 +120,11 @@ def _get_device(parent_dn, device_type, device_name):
             return None
         class_struct = load_class(policy_device_dict[device_type]["class_id"])
         access = policy_device_dict[device_type]["access"]
+        '''
+        cdrom and fdd are of type LsbootVirtualMedia and have "access" as the
+        naming property. Other objects under LsbootDef do not need this.
+        Hence cdrom and fdd need special handling below.
+        '''
         if device_type in ["cdrom", "fdd"]:
             class_obj = class_struct(parent_mo_or_dn=parent_dn, access=access)
         else:
@@ -347,7 +352,7 @@ def set_boot_order_policy(handle, reboot_on_update=False,
         reboot_on_update (bool): True, False
         secure_boot (bool): secure boot
         boot_devices (list of dict): format
-            [{"order":'1', "device-type":"vmedia", "name":"vmedia"},
+            [{"order":'1', "device-type":"cdrom", "name":"cdrom0"},
              {"order":'2', "device-type":"lan", "name":"lan"}]
 
             boot-order(string): Order
@@ -363,7 +368,7 @@ def set_boot_order_policy(handle, reboot_on_update=False,
             handle,
             reboot_on_update=False,
             secure_boot=True,
-            boot_devices = [{"order":'1', "device-type":"vmedia", "name":"vmedia"},
+            boot_devices = [{"order":'1', "device-type":"cdrom", "name":"cdrom0"},
                             {"order":'2', "device-type":"lan", "name":"lan"}]
 
 

--- a/imcsdk/imcmo.py
+++ b/imcsdk/imcmo.py
@@ -209,7 +209,7 @@ class ManagedObject(ImcBase):
 
     def set_prop_multiple(self, **kwargs):
         for prop_name in kwargs:
-            if imccoreutils.prop_exists(prop_name):
+            if imccoreutils.prop_exists(self, prop_name):
                 self.__set_prop(prop_name, kwargs[prop_name])
             else:
                 ImcWarning("Invalid Property Name for "

--- a/tests/server/test_boot_order.py
+++ b/tests/server/test_boot_order.py
@@ -15,8 +15,8 @@ from ..connection.info import custom_setup, custom_teardown
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_equal
 
-from imcsdk.apis.server.bios import get_boot_order_precision, \
-    set_boot_order_precision, set_boot_order_policy, get_boot_order_policy
+from imcsdk.apis.server.bios import set_boot_order_precision, \
+        set_boot_order_policy, get_boot_order_policy
 
 handle = None
 
@@ -31,27 +31,31 @@ def teardown_module():
     custom_teardown(handle)
 
 
-boot_order_prec_devices = [{"order": '1', "type": "hdd", "name": "hdd"},
-                           {"order": '2', "type": "pxe", "name": "pxe"},
-                           {"order": '3', "type": "pxe", "name": "pxe1"}]
+boot_order_prec_devices = [
+        {"order": '1', "device-type": "hdd", "name": "hdd"},
+        {"order": '2', "device-type": "pxe", "name": "pxe", "slot": "10", "port": "100"},
+        {"order": '3', "device-type": "pxe", "name": "pxe1"},
+        {"order": '4', "device-type": "usb", "name": "usb0", "subtype": "usb-cd"}]
+
 
 def test_boot_order_precision():
     global handle
     from imcsdk.apis.server.bios import get_configured_boot_precision
 
-    set_boot_order_precision(handle, reboot_on_update=True,
+    set_boot_order_precision(handle, reboot_on_update=False,
                              configured_boot_mode="Legacy",
                              boot_devices=boot_order_prec_devices)
 
     rcvd_boot_order = get_configured_boot_precision(handle)
     for ctr in range(0, len(rcvd_boot_order)):
         if boot_order_prec_devices[ctr]["order"] != rcvd_boot_order[ctr]["order"] or \
-           boot_order_prec_devices[ctr]["type"].lower() != rcvd_boot_order[ctr]["type"].lower():
+           boot_order_prec_devices[ctr]["device-type"].lower() != rcvd_boot_order[ctr]["device-type"].lower():
             raise SkipTest
 
 
-boot_order_policy_devices = [{"order": '1', "type": "storage", "name": "ext-hdd1"},
-                             {"order": '2', "type": "lan", "name": "mylan"}]
+boot_order_policy_devices = [{"order": '1', "device-type": "storage", "name": "ext-hdd1"},
+                             {"order": '2', "device-type": "lan", "name": "mylan"},
+                             {"order": '3', "device-type": "cdrom", "name": "mycdrom"}]
 
 
 def test_boot_order_policy():
@@ -65,7 +69,7 @@ def test_boot_order_policy():
     length = len(boot_order_policy_devices)
     for ctr in range(0, length):
         if boot_order_policy_devices[ctr]["order"] != rcvd_dev_list[ctr]["order"] or \
-           boot_order_policy_devices[ctr]["type"] != rcvd_dev_list[ctr]["type"]:
+           boot_order_policy_devices[ctr]["device-type"] != rcvd_dev_list[ctr]["device-type"]:
             raise SkipTest
 
 
@@ -76,9 +80,7 @@ def test_boot_order_precision_exists():
         handle,
         reboot_on_update=False,
         configured_boot_mode="Legacy",
-        boot_devices=[{"order": "1", "type": "hdd", "name": "hdd"},
-                      {"order": "2", "type": "pxe", "name": "pxe"},
-                      {"order": "3", "type": "pxe", "name": "pxe1"}],
+        boot_devices=boot_order_prec_devices,
         server_id=1
     )
     if not ret:


### PR DESCRIPTION
- check for conditionally configuring secure boot based on the MO version
- boot-order policy - fixed functionality for vmedia
- boot-order precision - handled extra boot device properties passed by the user
- updated tests
- fixed an issue while setting multiple properties

Signed-off-by: Swapnil Wagh <waghswapnil@gmail.com>