### PR TITLE
fixes to create_vnic api

### DIFF
--- a/imcsdk/apis/server/adaptor.py
+++ b/imcsdk/apis/server/adaptor.py
@@ -21,16 +21,25 @@ from imcsdk.imccoreutils import get_server_dn
 from imcsdk.imcexception import ImcOperationError
 
 
-def _get_adaptor(handle, adaptor_slot, server_id=1, **kwargs):
+def get_adaptor_unit(handle, adaptor_slot, server_id=1, **kwargs):
+    """
+    This method fetches the adaptorUnit Managed Object for the specified
+    adaptor Slot on a server.
 
+    Args:
+        handle (ImcHandle)
+        adaptor_slot (string): PCI slot number of the adaptor
+        server_id (int): Server Id for C3260 platforms
+        kwargs: key=value paired arguments
+
+    Examples:
+        get_adaptor_unit(handle, adaptor_slot=1, server_id=1)
+    """
     server_dn = get_server_dn(handle, server_id)
-    dn = server_dn + "/adaptor-" + str(adaptor_slot)
-    mo = handle.query_dn(dn)
+    mo = handle.query_dn(server_dn + "/adaptor-" + str(adaptor_slot))
 
     if mo is None:
-        raise ImcOperationError("Get Adaptor",
-                                "Adaptor is not available")
-
+        raise ImcOperationError("Get Adaptor Unit", "Adaptor is not available")
     return mo
 
 
@@ -133,29 +142,38 @@ def get_vnic(handle, adaptor_slot, name, server_id=1, **kwargs):
 
     from imcsdk.mometa.adaptor.AdaptorHostEthIf import AdaptorHostEthIf
 
-    mo = _get_adaptor(handle, adaptor_slot, server_id, **kwargs)
+    mo = get_adaptor_unit(handle, adaptor_slot, server_id, **kwargs)
     vnic_mo = AdaptorHostEthIf(parent_mo_or_dn=mo.dn, name=name)
     vnic_mo = handle.query_dn(vnic_mo.dn)
 
     return vnic_mo
 
 
-def create_vnic(handle, adaptor_slot, name, channel_number, mac, mtu=1500,
-                cos="", port_profile="", pxe_boot=False, uplink_port=0,
-                server_id=1, **kwargs):
+def create_vnic(handle,
+                name,
+                adaptor_slot=1,
+                channel_number=None,
+                mac="AUTO",
+                mtu=1500,
+                class_of_service=0,
+                port_profile="",
+                pxe_boot=False,
+                uplink_port=0,
+                server_id=1,
+                **kwargs):
     """
     This method is used to create a new vnic
     Args:
         handle (ImcHandle)
-        adaptor_slot (string): PCI slot number of the adaptor
         name (string): Name for the vnic
+        adaptor_slot (string): PCI slot number of the adaptor
         channel_number (int): channel number for the vnic
-        cos (string): class of service
+        class_of_service (int): class of service. 0-6
         mac (string): mac address for the vnic
         mtu (int): mtu size for the vnic
         port_profile (string): port-profile name
-        pxe_boot (bool): enable pxe_boot
-        uplink_port (int): uplink port for binding the vnic. "0", "1"
+        pxe_boot (bool): enable pxe_boot. True/False
+        uplink_port (int): uplink port for binding the vnic. 0/1
         server_id (int): Server Id for C3260 platforms
         kwargs: key=value paired arguments
 
@@ -176,37 +194,31 @@ def create_vnic(handle, adaptor_slot, name, channel_number, mac, mtu=1500,
 
     from imcsdk.mometa.adaptor.AdaptorHostEthIf import AdaptorHostEthIf
 
-    mo = _get_adaptor(handle, adaptor_slot, server_id, **kwargs)
-    vnic_mo = AdaptorHostEthIf(parent_mo_or_dn=mo.dn, name=name)
-    vnic_mo.channel_number = str(channel_number)
-    if cos:
-        vnic_mo.class_of_service = cos
-    vnic_mo.mac = mac
-    vnic_mo.mtu = str(mtu)
+    mo = get_adaptor_unit(handle, adaptor_slot, server_id, **kwargs)
+    vnic = AdaptorHostEthIf(parent_mo_or_dn=mo.dn, name=name)
+
+    vnic.mac = mac
+    vnic.mtu = str(mtu)
+    vnic.class_of_service = str(class_of_service)
+    vnic.pxe_boot = ("disabled", "enabled")[pxe_boot]
+    vnic.uplink_port = str(uplink_port)
+
+    if channel_number:
+        vnic.channel_number = str(channel_number)
     if port_profile:
-        vnic_mo.port_profile = port_profile
-    if pxe_boot:
-        vnic_mo.pxe_boot = "enabled"
-    else:
-        vnic_mo.pxe_boot = "disabled"
+        vnic.port_profile = port_profile
 
-    if uplink_port not in [0, 1]:
-        raise ImcOperationError("Create Vnic",
-                                "Invalid uplink port")
-
-    vnic_mo.uplink_port = str(uplink_port)
-    handle.add_mo(vnic_mo, modify_present=True)
-
-    return handle.query_dn(vnic_mo.dn)
+    handle.add_mo(vnic, modify_present=True)
+    return handle.query_dn(vnic.dn)
 
 
-def delete_vnic(handle, adaptor_slot, name, server_id=1, **kwargs):
+def delete_vnic(handle, name, adaptor_slot=1, server_id=1, **kwargs):
     """
     This method is used to delete a vnic
     Args:
         handle (ImcHandle)
-        adaptor_slot (string): PCI slot number of the adaptor
         name (string): Name for the vnic to be deleted
+        adaptor_slot (int): PCI slot number of the adaptor
         server_id (int): Server Id for C3260 platforms
         kwargs: key=value paired arguments
 
@@ -235,7 +247,7 @@ def get_vhba(handle, adaptor_slot, name, server_id=1, **kwargs):
 
     from imcsdk.mometa.adaptor.AdaptorHostFcIf import AdaptorHostFcIf
 
-    mo = _get_adaptor(handle, adaptor_slot, server_id, **kwargs)
+    mo = get_adaptor_unit(handle, adaptor_slot, server_id, **kwargs)
     vhba_mo = AdaptorHostFcIf(parent_mo_or_dn=mo.dn, name=name)
     vhba_mo = handle.query_dn(vhba_mo.dn)
 
@@ -276,7 +288,7 @@ def create_vhba(handle, adaptor_slot, name, channel_number, wwnn, wwpn,
 
     from imcsdk.mometa.adaptor.AdaptorHostFcIf import AdaptorHostFcIf
 
-    mo = _get_adaptor(handle, adaptor_slot, server_id, **kwargs)
+    mo = get_adaptor_unit(handle, adaptor_slot, server_id, **kwargs)
     vhba_mo = AdaptorHostFcIf(parent_mo_or_dn=mo.dn, name=name)
     vhba_mo.channel_number = str(channel_number)
     vhba_mo.wwnn = wwnn

--- a/imcsdk/apis/server/adaptor.py
+++ b/imcsdk/apis/server/adaptor.py
@@ -155,7 +155,7 @@ def create_vnic(handle,
                 channel_number=None,
                 mac="AUTO",
                 mtu=1500,
-                class_of_service=0,
+                class_of_service=None,
                 port_profile="",
                 pxe_boot=False,
                 uplink_port=0,
@@ -199,10 +199,11 @@ def create_vnic(handle,
 
     vnic.mac = mac
     vnic.mtu = str(mtu)
-    vnic.class_of_service = str(class_of_service)
     vnic.pxe_boot = ("disabled", "enabled")[pxe_boot]
     vnic.uplink_port = str(uplink_port)
 
+    if class_of_service:
+        vnic.class_of_service = str(class_of_service)
     if channel_number:
         vnic.channel_number = str(channel_number)
     if port_profile:

--- a/imcsdk/apis/server/bios.py
+++ b/imcsdk/apis/server/bios.py
@@ -259,7 +259,11 @@ def boot_order_precision_exists(handle, **kwargs):
 
     mo = mos[0]
 
-    args = {"reboot_on_update": kwargs.get("reboot_on_update"),
+    reboot_on_update = kwargs.get("reboot_on_update")
+    if isinstance(reboot_on_update, bool):
+        reboot_on_update = ("no", "yes")[reboot_on_update]
+
+    args = {"reboot_on_update": reboot_on_update,
             "configured_boot_mode": kwargs.get("configured_boot_mode")}
     if not mo.check_prop_match(**args):
         return False, "parent MO property values do not match"

--- a/imcsdk/apis/server/bios.py
+++ b/imcsdk/apis/server/bios.py
@@ -23,7 +23,7 @@ from imcsdk.mometa.lsboot.LsbootDevPrecision import LsbootDevPrecision
 log = logging.getLogger('imc')
 
 
-def get_boot_order_precision(handle, dump=False, server_id=1):
+def boot_order_precision_get(handle, dump=False, server_id=1):
     """
     Gets the precision boot order.
     This is supported from EP release onwards only
@@ -139,7 +139,7 @@ def _get_device(parent_dn, device_type, device_name):
 def _add_boot_device(handle, parent_dn, boot_device):
     """
     This method verifies and adds the boot device in the boot order
-    Used by set_boot_order_precision and set_boot_order_policy
+    Used by boot_order_precision_set and boot_order_policy_set
 
     Args:
         handle(ImcHandle)
@@ -166,7 +166,7 @@ def _add_boot_device(handle, parent_dn, boot_device):
     handle.add_mo(device, modify_present=True)
 
 
-def set_boot_order_precision(
+def boot_order_precision_set(
         handle, reboot_on_update=True, configured_boot_mode="Legacy",
         boot_devices=[], server_id=1):
     """
@@ -194,7 +194,7 @@ def set_boot_order_precision(
         LsBootDevPrecision object
 
     Examples:
-        set_boot_order_precision(
+        boot_order_precision_set(
             handle,
              reboot_on_update=False,
              configured_boot_mode="Uefi",
@@ -228,7 +228,7 @@ def set_boot_order_precision(
     return lsbootdevprecision_mo
 
 
-def get_configured_boot_precision(handle, server_id=1):
+def boot_precision_configured_get(handle, server_id=1):
     from imcsdk.imccoreutils import get_server_dn
 
     configured_boot_order = []
@@ -272,7 +272,7 @@ def boot_order_precision_exists(handle, **kwargs):
         in_boot_order = sorted(
             kwargs["boot_devices"],
             key=lambda x: x["order"])
-        configured_boot_order = get_configured_boot_precision(
+        configured_boot_order = boot_precision_configured_get(
             handle, kwargs.get("server_id"))
 
         if len(in_boot_order) != len(configured_boot_order):
@@ -285,7 +285,7 @@ def boot_order_precision_exists(handle, **kwargs):
     return True, None
 
 
-def get_boot_order_policy(handle, dump=False, server_id=1):
+def boot_order_policy_get(handle, dump=False, server_id=1):
     """
     Gets the boot order. This is the legacy boot order
 
@@ -300,7 +300,7 @@ def get_boot_order_policy(handle, dump=False, server_id=1):
             [{"order": '1', "device-type": "pxe", "name": "pxe"}]
 
     Example:
-        get_boot_order_policy(handle, dump=False)
+        boot_order_policy_get(handle, dump=False)
     """
 
     from imcsdk.mometa.lsboot.LsbootBootSecurity import LsbootBootSecurity
@@ -344,7 +344,7 @@ def get_boot_order_policy(handle, dump=False, server_id=1):
     return sorted_boot_order_list
 
 
-def set_boot_order_policy(handle, reboot_on_update=False,
+def boot_order_policy_set(handle, reboot_on_update=False,
                           secure_boot=False, boot_devices=[], server_id=1):
     """
     This method will set the boot order policy passed from the user
@@ -368,7 +368,7 @@ def set_boot_order_policy(handle, reboot_on_update=False,
         LsBootDef object
 
     Examples:
-        set_boot_order_policy(
+        boot_order_policy_set(
             handle,
             reboot_on_update=False,
             secure_boot=True,

--- a/imcsdk/imcmo.py
+++ b/imcsdk/imcmo.py
@@ -343,9 +343,9 @@ class ManagedObject(ImcBase):
             xml_obj.set('dn', self.dn)
 
         self.child_to_xml(xml_obj, option, cookie=cookie)
-        if unknown_properties:
-            log.info("List of properties not applicable for the current platform:")
-            log.info(unknown_properties)
+        # if unknown_properties:
+        #     log.info("List of properties not applicable for the current platform:")
+        #     log.info(unknown_properties)
 
         return xml_obj
 

--- a/tests/server/test_adaptor.py
+++ b/tests/server/test_adaptor.py
@@ -32,6 +32,31 @@ def teardown_module():
     custom_teardown(handle)
 
 
+def test_non_vntag_mode():
+    global handle
+    setup_vic_adaptor_properties(handle, adaptor_slot=ADAPTOR_ID, fip_mode=True,
+                                 vntag_mode=False)
+    mo = get_vic_adaptor_properties(handle, adaptor_slot=ADAPTOR_ID)
+    assert_equal(mo.vntag_mode.lower(), "disabled")
+
+
+def test_non_vntag_create_vnic():
+    global handle
+    vnic_mo = create_vnic(handle, adaptor_slot=ADAPTOR_ID, name="sdk-test-vnic-nv",
+                          class_of_service=5, mac="00:11:22:33:44:56",
+                          mtu=1500, pxe_boot=True, uplink_port=0)
+    rcvd_mo = get_vnic(handle, adaptor_slot=ADAPTOR_ID, name="sdk-test-vnic-nv")
+    assert_not_equal(rcvd_mo, None)
+    assert_equal(vnic_mo.name, rcvd_mo.name)
+    assert_equal(vnic_mo.class_of_service, rcvd_mo.class_of_service)
+
+
+def test_delete_vnic():
+    global handle
+    delete_vnic(handle, adaptor_slot=ADAPTOR_ID, name="sdk-test-vnic-nv")
+    assert_equal(get_vnic(handle, adaptor_slot=ADAPTOR_ID, name="sdk-test-vnic-nv"), None)
+
+
 def test_enable_adaptor_properties():
     global handle
     setup_vic_adaptor_properties(handle, adaptor_slot=ADAPTOR_ID, fip_mode=True,

--- a/tests/server/test_boot_order.py
+++ b/tests/server/test_boot_order.py
@@ -15,8 +15,8 @@ from ..connection.info import custom_setup, custom_teardown
 from nose.plugins.skip import SkipTest
 from nose.tools import assert_equal
 
-from imcsdk.apis.server.bios import set_boot_order_precision, \
-        set_boot_order_policy, get_boot_order_policy
+from imcsdk.apis.server.bios import boot_order_precision_set, \
+        boot_order_policy_set, boot_order_policy_get
 
 handle = None
 
@@ -40,13 +40,13 @@ boot_order_prec_devices = [
 
 def test_boot_order_precision():
     global handle
-    from imcsdk.apis.server.bios import get_configured_boot_precision
+    from imcsdk.apis.server.bios import boot_precision_configured_get
 
-    set_boot_order_precision(handle, reboot_on_update=False,
+    boot_order_precision_set(handle, reboot_on_update=False,
                              configured_boot_mode="Legacy",
                              boot_devices=boot_order_prec_devices)
 
-    rcvd_boot_order = get_configured_boot_precision(handle)
+    rcvd_boot_order = boot_precision_configured_get(handle)
     for ctr in range(0, len(rcvd_boot_order)):
         if boot_order_prec_devices[ctr]["order"] != rcvd_boot_order[ctr]["order"] or \
            boot_order_prec_devices[ctr]["device-type"].lower() != rcvd_boot_order[ctr]["device-type"].lower():
@@ -61,11 +61,11 @@ boot_order_policy_devices = [{"order": '1', "device-type": "storage", "name": "e
 def test_boot_order_policy():
     global handle
 
-    set_boot_order_policy(handle, reboot_on_update=True,
+    boot_order_policy_set(handle, reboot_on_update=True,
                           secure_boot=False,
                           boot_devices=boot_order_policy_devices)
 
-    rcvd_dev_list = get_boot_order_policy(handle)
+    rcvd_dev_list = boot_order_policy_get(handle)
     length = len(boot_order_policy_devices)
     for ctr in range(0, length):
         if boot_order_policy_devices[ctr]["order"] != rcvd_dev_list[ctr]["order"] or \


### PR DESCRIPTION
`exists` related APIs added
default values added to `create_vnic` API.
API naming has been changed to be consistent.
