### PR TITLE
add apis for ntp

### DIFF
--- a/imcsdk/apis/admin/ntp.py
+++ b/imcsdk/apis/admin/ntp.py
@@ -1,0 +1,175 @@
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+This module implements all the ntp related functionality
+"""
+from imcsdk.mometa.comm.CommNtpProvider import CommNtpProvider
+from imcsdk.imccoreutils import _is_valid_arg
+
+
+def _get_ntp_mo(handle=None, from_server=False):
+    from imcsdk.imcexception import ImcOperationError
+
+    mo = CommNtpProvider(parent_mo_or_dn="sys/svc-ext")
+    if from_server:
+        if handle is None:
+            raise ImcOperationError("Get NTP Settings", "Handle is None")
+
+        mo = handle.query_dn(mo.dn)
+        if mo is None:
+            raise ImcOperationError("Get NTP Settings", "MO doesn't exist")
+    return mo
+
+
+def _set_ntp_servers(mo, ntp_servers):
+    args = {}
+    for server in ntp_servers:
+        key = "ntp_server" + str(server["id"])
+        args[key] = server["ip"]
+    mo.set_prop_multiple(**args)
+
+
+def ntp_enable(handle, ntp_servers=[]):
+    """
+    Enable NTP
+
+    Args:
+        handle (ImcHandle)
+        ntp_servers (list): List of dictionaries of the type
+                            [{"id": 1, "ip": "192.168.1.1"},
+                             {"id": 2, "ip": "192.168.1.2"}]
+                            Upto 4 ntp servers can be specified.
+
+    Returns:
+        CommNtpProvider object
+
+    Example:
+        ntp_enable(handle,
+                   ntp_servers = [{"id": 1, "ip": "192.168.1.1"},
+                                  {"id": 2, "ip": "192.168.1.2"}]
+    """
+
+    mo = _get_ntp_mo()
+    mo.ntp_enable = "yes"
+
+    _set_ntp_servers(mo, ntp_servers)
+    handle.set_mo(mo)
+    return handle.query_dn(mo.dn)
+
+
+def ntp_disable(handle):
+    """
+    Disable NTP
+    Args:
+        handle (ImcHandle)
+
+    Returns:
+        CommNtpProvider object
+    """
+
+    mo = _get_ntp_mo()
+    mo.ntp_enable = "no"
+
+    handle.set_mo(mo)
+    return handle.query_dn(mo.dn)
+
+
+def ntp_servers_modify(handle, ntp_servers=[]):
+    """
+    Modify the configured NTP servers
+    Args:
+        handle (ImcHandle)
+        ntp_servers (list): List of dictionaries of the type
+                            [{"id": 1, "ip": "192.168.1.1"},
+                             {"id": 2, "ip": "192.168.1.2"}]
+                            Upto 4 ntp servers can be specified.
+
+    Returns:
+        CommNtpProvider object
+
+    Example:
+        ntp_servers_modify(handle,
+                           ntp_servers = [{"id": 1, "ip": "192.168.1.1"},
+                                          {"id": 2, "ip": "192.168.1.2"},
+                                          {"id": 3, "ip": ""}]
+    """
+
+    # While sending the modified list of servers, it is imperative to send
+    # ntp_enable property in the request.
+    # Hence, query the MO and reassign the same value to ntp_enable
+    mo = _get_ntp_mo(handle, from_server=True)
+    mo.ntp_enable = mo.ntp_enable
+    _set_ntp_servers(mo, ntp_servers)
+
+    handle.set_mo(mo)
+    return mo
+
+
+def is_ntp_enabled(handle):
+    """
+    Check if NTP is enabled
+    Args:
+        handle (ImcHandle)
+
+    Returns:
+        bool
+    """
+
+    mo = _get_ntp_mo(handle, from_server=True)
+    return (mo.ntp_enable.lower() in ["true", "yes"])
+
+
+def _is_invalid_value(value):
+    return value in ["", None]
+
+
+def _check_ntp_server_match(ntp_mo, mo):
+    for prop in ["ntp_server1", "ntp_server2",
+                 "ntp_server3", "ntp_server4"]:
+        configured_value = getattr(ntp_mo, prop)
+        in_value = getattr(mo, prop)
+
+        if _is_invalid_value(configured_value) and \
+                _is_invalid_value(in_value):
+            continue
+        if configured_value != in_value:
+            return False
+
+    return True
+
+
+def ntp_setting_exists(handle, **kwargs):
+    """
+    Check if the specified NTP settings are already applied
+    Args:
+        handle (ImcHandle)
+        kwargs: key-value paired arguments
+
+    Returns:
+        (True, CommNtpProvider) if settings match, (False, None) otherwise
+    """
+
+    ntp_mo = _get_ntp_mo(handle, from_server=True)
+
+    if ntp_mo.ntp_enable != kwargs.get("ntp_enable"):
+        return False, None
+
+    if _is_valid_arg("ntp_servers", kwargs):
+        mo = _get_ntp_mo()
+        _set_ntp_servers(mo, kwargs.get("ntp_servers"))
+        if not _check_ntp_server_match(ntp_mo, mo):
+            return False, None
+
+    return True, ntp_mo

--- a/imcsdk/apis/server/adaptor.py
+++ b/imcsdk/apis/server/adaptor.py
@@ -108,8 +108,9 @@ def setup_vic_adaptor_properties(handle, adaptor_slot, fip_mode=None,
     """
 
     mo = get_vic_adaptor_properties(handle, adaptor_slot, server_id, **kwargs)
-    if num_vmfex_ifs:
-        mo.num_of_vm_fex_ifs = str(num_vmfex_ifs)
+    # VMFEX feature support is discontinued
+    # if num_vmfex_ifs:
+    #     mo.num_of_vm_fex_ifs = str(num_vmfex_ifs)
 
     if fip_mode is True:
         mo.fip_mode = "enabled"

--- a/imcsdk/apis/server/remotepresence.py
+++ b/imcsdk/apis/server/remotepresence.py
@@ -426,6 +426,7 @@ def sol_setup(handle, speed, com_port, ssh_port, server_id=1):
     solif_mo.ssh_port = str(ssh_port)
 
     handle.set_mo(solif_mo)
+    return handle.query_dn(solif_mo.dn)
 
 
 def sol_disable(handle, server_id=1):

--- a/imcsdk/imcmo.py
+++ b/imcsdk/imcmo.py
@@ -317,7 +317,7 @@ class ManagedObject(ImcBase):
                             prop.mask and
                             self._dirty_mask & prop.mask != 0)):
                     value = getattr(self, key)
-                    if value:
+                    if value is not None:
                         xml_obj.set(prop.xml_attribute, value)
             else:
                 if key not in self.__xtra_props:

--- a/imcsdk/utils/imcfirmwareinstall.py
+++ b/imcsdk/utils/imcfirmwareinstall.py
@@ -14,6 +14,7 @@
 
 import time
 import datetime
+import logging
 from imcsdk.imcgenutils import *
 from imcsdk.imccoreutils import IMC_PLATFORM, get_server_dn
 from imcsdk.mometa.huu.HuuFirmwareUpdater import HuuFirmwareUpdater, \
@@ -22,6 +23,7 @@ from imcsdk.mometa.huu.HuuFirmwareUpdateStatus import HuuFirmwareUpdateStatus
 from imcsdk.mometa.top.TopSystem import TopSystem
 from imcsdk.mometa.huu.HuuController import HuuController
 
+log = logging.getLogger('imc')
 
 def update_imc_firmware_huu(handle, remote_share, share_type, remote_ip,
                             username="", password="", update_component="all",

--- a/tests/server/test_ntp.py
+++ b/tests/server/test_ntp.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, raises
 from ..connection.info import custom_setup, custom_teardown
 
 from imcsdk.apis.admin.ntp import ntp_enable, ntp_disable, is_ntp_enabled, \
@@ -35,7 +35,14 @@ ntp_servers = [{"id": 1, "ip": "192.168.1.1"},
                {"id": 3, "ip": "192.168.1.3"},
                {"id": 4, "ip": "1.2.3.4"}]
 
-ntp_servers_1 = [{"id": 1, "ip": "192.168.1.1"},
+ntp_servers_2 = [{"id": 1, "ip": "192.168.1.1"},
+                 {"id": 2, "ip": ""},
+                 {"id": 3, "ip": "192.168.1.3"},
+                 {"id": 4, "ip": "1.1.1.1"},
+                 {"id": 5, "ip": "2.2.2.2"}]
+
+
+ntp_servers_3 = [{"id": 1, "ip": "192.168.1.1"},
                  {"id": 2, "ip": ""},
                  {"id": 3, "ip": "192.168.1.3"},
                  {"id": 4, "ip": "1.1.1.1"}]
@@ -53,17 +60,33 @@ def test_ntp_setting_exists():
     assert_equal(match, True)
 
 
+@raises(Exception)
+def test_ntp_enable_2():
+    ntp_enable(handle, ntp_servers=ntp_servers_2)
+    match, mo = ntp_setting_exists(handle,
+                                   ntp_servers=ntp_servers_2)
+    assert_equal(match, True)
+
+
+@raises(Exception)
 def test_ntp_setting_exists_2():
+    match, mo = ntp_setting_exists(handle,
+                                   ntp_enable="yes",
+                                   ntp_servers=ntp_servers_2)
+    assert_equal(match, True)
+
+
+def test_ntp_setting_exists_3():
     match, mo = ntp_setting_exists(handle,
                                    ntp_enable="yes")
     assert_equal(match, True)
 
 
 def test_ntp_servers_modify():
-    ntp_servers_modify(handle, ntp_servers=ntp_servers_1)
+    ntp_servers_modify(handle, ntp_servers=ntp_servers_3)
     match, mo = ntp_setting_exists(handle,
                                    ntp_enable="yes",
-                                   ntp_servers=ntp_servers_1)
+                                   ntp_servers=ntp_servers_3)
     assert_equal(match, True)
 
 

--- a/tests/server/test_ntp.py
+++ b/tests/server/test_ntp.py
@@ -15,7 +15,7 @@ from nose.tools import assert_equal, raises
 from ..connection.info import custom_setup, custom_teardown
 
 from imcsdk.apis.admin.ntp import ntp_enable, ntp_disable, is_ntp_enabled, \
-        ntp_setting_exists, ntp_servers_modify
+        ntp_setting_exists, ntp_servers_modify, ntp_servers_clear
 
 handle = None
 
@@ -90,6 +90,32 @@ def test_ntp_servers_modify():
     assert_equal(match, True)
 
 
+def test_ntp_servers_clear():
+    ntp_servers_clear(handle, ntp_servers=["192.168.1.3", "1.1.1.1"])
+    match, mo = ntp_setting_exists(handle, ntp_enable="yes",
+                                   ntp_servers=[{"id": 1, "ip": "192.168.1.1"}])
+    assert_equal(match, True)
+
+
+@raises(Exception)
+def test_ntp_servers_clear_all_enabled():
+    ntp_servers_clear(handle)
+    match, mo = ntp_setting_exists(handle, ntp_enable="yes",
+                                   ntp_servers=[{"id": 1, "ip": ""},
+                                                {"id": 2, "ip": ""},
+                                                {"id": 3, "ip": ""},
+                                                {"id": 4, "ip": ""}])
+
+
 def test_ntp_disable():
     ntp_disable(handle)
     assert_equal(is_ntp_enabled(handle), False)
+
+
+def test_ntp_servers_clear_all_disabled():
+    ntp_servers_clear(handle)
+    match, mo = ntp_setting_exists(handle, ntp_enable="no",
+                                   ntp_servers=[{"id": 1, "ip": ""},
+                                                {"id": 2, "ip": ""},
+                                                {"id": 3, "ip": ""},
+                                                {"id": 4, "ip": ""}])

--- a/tests/server/test_ntp.py
+++ b/tests/server/test_ntp.py
@@ -1,0 +1,72 @@
+# Copyright 2016 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nose.tools import assert_equal
+from ..connection.info import custom_setup, custom_teardown
+
+from imcsdk.apis.admin.ntp import ntp_enable, ntp_disable, is_ntp_enabled, \
+        ntp_setting_exists, ntp_servers_modify
+
+handle = None
+
+
+def setup_module():
+    global handle
+    handle = custom_setup()
+
+
+def teardown_module():
+    global handle
+    custom_teardown(handle)
+
+
+ntp_servers = [{"id": 1, "ip": "192.168.1.1"},
+               {"id": 2, "ip": "192.168.1.2"},
+               {"id": 3, "ip": "192.168.1.3"},
+               {"id": 4, "ip": "1.2.3.4"}]
+
+ntp_servers_1 = [{"id": 1, "ip": "192.168.1.1"},
+                 {"id": 2, "ip": ""},
+                 {"id": 3, "ip": "192.168.1.3"},
+                 {"id": 4, "ip": "1.1.1.1"}]
+
+
+def test_ntp_enable():
+    ntp_enable(handle, ntp_servers=ntp_servers)
+    assert_equal(is_ntp_enabled(handle), True)
+
+
+def test_ntp_setting_exists():
+    match, mo = ntp_setting_exists(handle,
+                                   ntp_enable="yes",
+                                   ntp_servers=ntp_servers)
+    assert_equal(match, True)
+
+
+def test_ntp_setting_exists_2():
+    match, mo = ntp_setting_exists(handle,
+                                   ntp_enable="yes")
+    assert_equal(match, True)
+
+
+def test_ntp_servers_modify():
+    ntp_servers_modify(handle, ntp_servers=ntp_servers_1)
+    match, mo = ntp_setting_exists(handle,
+                                   ntp_enable="yes",
+                                   ntp_servers=ntp_servers_1)
+    assert_equal(match, True)
+
+
+def test_ntp_disable():
+    ntp_disable(handle)
+    assert_equal(is_ntp_enabled(handle), False)


### PR DESCRIPTION
- APIs for NTP 
- Deprecate the vmfex attribute for adaptors
- Allow sending properties with empty-string as a value in the request

Signed-off-by: Swapnil Wagh <waghswapnil@gmail.com>