### PR TITLE
support for on demand dump xml and file logging at global level

### DIFF
--- a/imcsdk/__init__.py
+++ b/imcsdk/__init__.py
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 
+import os
 import logging
 import logging.handlers
 
@@ -50,6 +51,9 @@ def set_log_level(level=logging.DEBUG):
 set_log_level(logging.DEBUG)
 
 log.addHandler(console)
+
+if os.path.exists('/tmp/imcsdk_debug'):
+    enable_file_logging()
 
 __author__ = 'Cisco Systems'
 __email__ = 'ucs-python@cisco.com'

--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -14,6 +14,7 @@
 
 import time
 import logging
+import os
 from threading import Timer
 
 from .imcexception import ImcException, ImcLoginError
@@ -57,6 +58,10 @@ class ImcSession(object):
         self.__dump_xml = False
         self.__redirect = False
         self.__driver = ImcDriver(proxy=self.__proxy)
+
+        # In debug mode, log the XMLs to a file
+        if os.path.exists('/tmp/imcsdk_debug'):
+            self.__dump_xml = True
 
     @property
     def ip(self):


### PR DESCRIPTION
`touch /tmp/imcsdk_debug` would create a file imcsdk.log in the current directory and start logging all XML transactions to it.

Signed-off-by: vvb <vvb@cisco.com>