### PR TITLE
docstring change for ip filtering and bios_profile_exists fix

### DIFF
--- a/imcsdk/apis/admin/ip.py
+++ b/imcsdk/apis/admin/ip.py
@@ -153,7 +153,7 @@ def _set_ip_filters(mo, filters):
 def ip_filtering_enable(handle, filters=[]):
     """
     Enables IP filtering with the filters specified
-    Connection is expected to drop.
+    Connection may drop during this activity.
 
     Args:
         handle (ImcHandle)
@@ -217,7 +217,8 @@ def is_ip_filtering_enabled(handle):
 
 def ip_filtering_modify(handle, filters=[]):
     """
-    Modifies IP filtering with the filters specified
+    Modifies IP filtering with the filters specified.
+    Connection may drop during this activity.
 
     Args:
         handle (ImcHandle)
@@ -243,7 +244,8 @@ def ip_filtering_modify(handle, filters=[]):
 
 def ip_filtering_clear(handle, filter_id=''):
     """
-    Clears the IP filters specified by
+    Clears the IP filters specified by the input.
+    Connection may drop during this activity.
 
     Args:
         handle (ImcHandle)

--- a/imcsdk/apis/server/bios.py
+++ b/imcsdk/apis/server/bios.py
@@ -694,15 +694,15 @@ def bios_profile_exists(handle, name, server_id=1, **kwargs):
     Returns:
         (True, BiosProfile) if the settings match, else (False, None)
 
-    Raises:
-        ImcOperationError if the bios profile is not found
-
     Examples:
         match, mo = bios_profile_exists(handle, name='simple',
                                         enabled=True)
     """
 
-    mo = _get_bios_profile(handle, name=name, server_id=server_id)
+    mo = _get_bios_profile_mo(handle, name=name, server_id=server_id)
+    if mo is None:
+        return False, None
+
     params = {}
 
     if _is_valid_arg('enabled', kwargs):
@@ -743,7 +743,7 @@ def bios_profile_generate_json(handle, name, server_id=1, file_name=None):
     output = {}
     output['tokens'] = {}
 
-    mo = _get_bios_profile_mo(handle, name=name, server_id=server_id)
+    mo = _get_bios_profile(handle, name=name, server_id=server_id)
     output['name'] = mo.name
     output['description'] = mo.description
 

--- a/tests/server/test_bios_profile.py
+++ b/tests/server/test_bios_profile.py
@@ -77,6 +77,11 @@ def test_bios_profile_exists():
     assert_equal(match, True)
 
 
+def test_bios_profile_not_exists():
+    match, mo = bios_profile_exists(handle, name='complex')
+    assert_equal(match, False)
+
+
 def test_bios_profile_generate_json():
     diff = []
     output = bios_profile_generate_json(handle, name='simple')


### PR DESCRIPTION
- docstring change to indicate about connection drop
- bios_profile_exists should return (False, None) for a non-existing profile instead of raising an exception

Signed-off-by: Swapnil Wagh <waghswapnil@gmail.com>