### PR TITLE
add context manager support for ImcHandle

### DIFF
--- a/imcsdk/imchandle.py
+++ b/imcsdk/imchandle.py
@@ -34,6 +34,10 @@ class ImcHandle(ImcSession):
         port (int or None): The port number to be used during connection
         secure (bool or None): True for secure connection, otherwise False
         proxy (str): The proxy object to be used to connect
+        auto_refresh (bool): if set to True, it'll refresh the cookie continuously
+        force (bool): if set to True it'll reconnect even if cookie exists
+            and is valid for the respective connection.
+        timeout (int): timeout value in secs
 
     Example:
         handle = ImcHandle("192.168.1.1","admin","password")\n
@@ -48,10 +52,31 @@ class ImcHandle(ImcSession):
     """
 
     def __init__(self, ip, username, password, port=None, secure=None,
-                 proxy=None):
-        ImcSession.__init__(self, ip, username, password, port,
-                            secure, proxy)
+                 proxy=None, auto_refresh=False, force=False, timeout=None):
+
+        ImcSession.__init__(self, ip=ip, username=username, password=password,
+                            port=port, secure=secure, proxy=proxy,
+                            auto_refresh=auto_refresh, force=force,
+                            timeout=timeout)
         self.__to_commit = {}
+
+    def __enter__(self):
+        """
+        Initiates a connection to the server referenced by the ImcHandle.
+        A cookie is populated in the ImcHandle, if the login is successful.
+
+        The class instance is returned.
+        """
+
+        self._login()
+        return self
+
+    def __exit__(self, *exc):
+        """
+        Disconnects from the server referenced by the ImcHandle and exits.
+        """
+
+        self._logout()
 
     def set_dump_xml(self):
         """
@@ -67,7 +92,7 @@ class ImcHandle(ImcSession):
 
         self._unset_dump_xml()
 
-    def login(self, auto_refresh=False, force=False, timeout=None):
+    def login(self, auto_refresh=None, force=None, timeout=None):
         """
         Initiates a connection to the server referenced by the ImcHandle.
         A cookie is populated in the ImcHandle, if the login is successful.
@@ -75,8 +100,8 @@ class ImcHandle(ImcSession):
         Args:
             auto_refresh (bool): if set to True, it refresh the cookie
                 continuously
-            force (bool): if set to True it reconnects even if cookie exists
-                and is valid for respective connection.
+            force (bool): if set to True it'll reconnect even if cookie exists
+                and is valid for the respective connection.
             timeout (int): timeout value in secs
 
         Returns:
@@ -91,7 +116,7 @@ class ImcHandle(ImcSession):
             where handle is ImcHandle()
         """
 
-        return self._login(auto_refresh, force, timeout=timeout)
+        return self._login(auto_refresh=auto_refresh, force=force, timeout=timeout)
 
     def logout(self, timeout=None):
         """

--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -31,11 +31,13 @@ class ImcSession(object):
     """
 
     def __init__(self, ip, username, password, port=None, secure=None,
-                 proxy=None):
+                 proxy=None, auto_refresh=False, force=False, timeout=None):
         self.__ip = ip
         self.__username = username
         self.__password = password
         self.__proxy = proxy
+        self.__auto_refresh = auto_refresh
+        self.__timeout = timeout
         self.__uri = self.__create_uri(port, secure)
         self.__platform = None
         self.__model = None
@@ -53,7 +55,7 @@ class ImcSession(object):
         self.__last_update_time = None
 
         self.__refresh_timer = None
-        self.__force = False
+        self.__force = force
 
         self.__dump_xml = False
         self.__redirect = False
@@ -190,7 +192,7 @@ class ImcSession(object):
 
     def post(self, uri, data=None, read=True, timeout=None):
         """
-        sends the request and receives the response from imcm server
+        sends the request and receives the response from the imc server
 
         Args:
             uri (str): URI of the  the imc Server
@@ -203,12 +205,13 @@ class ImcSession(object):
             response = post("http://192.168.1.1:80", data=xml_str)
         """
 
+        timeout = timeout if timeout is not None else self.__timeout
         response = self.__driver.post(uri=uri, data=data, read=read, timeout=timeout)
         return response
 
     def post_xml(self, xml_str, read=True, timeout=None):
         """
-        sends the xml request and receives the response from imc server
+        sends the xml request and receives the response from the imc server
 
         Args:
             xml_str (str): xml string
@@ -250,7 +253,7 @@ class ImcSession(object):
 
     def post_elem(self, elem, timeout=None):
         """
-        sends the request and receives the response from imc server using xml
+        sends the request and receives the response from the imc server using xml
         element
 
         Args:
@@ -295,7 +298,7 @@ class ImcSession(object):
             file_name,
             progress=Progress()):
         """
-        Downloads the file from imc server
+        Downloads the file from the imc server
 
         Args:
             url_suffix (str): suffix url to be appended to
@@ -545,7 +548,7 @@ class ImcSession(object):
         self.__imc = top_system.name
         self.__virtual_ipv4_address = top_system.address
 
-    def _login(self, auto_refresh=False, force=False, timeout=None):
+    def _login(self, auto_refresh=None, force=None, timeout=None):
         """
         Internal method responsible to do a login on imc server.
 
@@ -554,6 +557,7 @@ class ImcSession(object):
                                     continuously
             force (bool): if set to True it reconnects even if cookie exists
                                     and is valid for respective connection.
+            timeout (int): timeout value in secs
 
         Returns:
             True on successful connect
@@ -561,7 +565,8 @@ class ImcSession(object):
         from .imcmethodfactory import aaa_login
         from .imccoreutils import add_handle_to_list
 
-        self.__force = force
+        self.__force = force if force is not None else self.__force
+        auto_refresh = auto_refresh if auto_refresh is not None else self.__auto_refresh
 
         if self._validate_connection():
             return True
@@ -589,7 +594,7 @@ class ImcSession(object):
 
     def _logout(self, timeout=None):
         """
-        Internal method to disconnect from imc server.
+        Internal method to disconnect from the imc server.
 
         Args:
             None

--- a/tests/connection/info.py
+++ b/tests/connection/info.py
@@ -11,6 +11,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+CONNECTION_CFG_FILEPATH = os.path.join(os.path.dirname(__file__), '..', 'connection',
+                          'connection.cfg')
 
 def custom_setup(host="imc"):
     try:
@@ -18,12 +22,10 @@ def custom_setup(host="imc"):
     except:
         import configparser as ConfigParser
 
-    import os
     from imcsdk.imchandle import ImcHandle
 
     config = ConfigParser.RawConfigParser()
-    config.read(os.path.join(os.path.dirname(__file__), '..', 'connection',
-                             'connection.cfg'))
+    config.read(CONNECTION_CFG_FILEPATH)
 
     hostname = config.get(host, "hostname")
     username = config.get(host, "username")

--- a/tests/session/test_imcsession.py
+++ b/tests/session/test_imcsession.py
@@ -91,3 +91,30 @@ def test_imc_timeout():
     except urllib2.URLError as e:
         print("Hit expected error")
         raise Exception
+
+
+def test_imc_context_manager_no_timeout():
+    try:
+        import ConfigParser
+    except:
+        import configparser as ConfigParser
+
+    from imcsdk.imchandle import ImcHandle
+    from ..connection import info
+
+    config = ConfigParser.RawConfigParser()
+    config.read(info.CONNECTION_CFG_FILEPATH)
+    hostname = config.get(host, "hostname")
+    username = config.get(host, "username")
+    password = config.get(host, "password")
+
+    handle = ImcHandle(hostname, username, password)
+    with handle:
+        server_dn = get_server_dn(handle)
+        mo = handle.query_dn(server_dn, timeout=600)
+        usr_lbl = "test-lbl2"
+        mo.usr_lbl = usr_lbl
+        handle.set_mo(mo, timeout=600)
+        mo = handle.query_dn(server_dn)
+
+    assert_equal(mo.usr_lbl, usr_lbl)


### PR DESCRIPTION
- moves `ImcHandle.login` defaults to `ImcHandle.__init__`
    this is so `ImcHandle._login` and `ImcHandle.__enter__`
    use the same defaults.

