### PR TITLE
Sync mo bug

### DIFF
--- a/imcsdk/apis/admin/snmp.py
+++ b/imcsdk/apis/admin/snmp.py
@@ -359,7 +359,7 @@ def snmp_user_get(handle, name):
     return None
 
 
-def snmp_user_exists(handle, name):
+def snmp_user_exists(handle, name, **kwargs):
     """
     checks if snmp user exists.
 
@@ -373,9 +373,11 @@ def snmp_user_exists(handle, name):
     Example:
         snmp_user_exists(handle, name="snmpuser")
     """
+    kwargs.pop('auth_pwd', None)
+    kwargs.pop('privacy_pwd', None)
 
     user = snmp_user_get(handle, name=name)
-    if user:
+    if user and user.check_prop_match(**kwargs):
         return (True, user)
     return (False, None)
 

--- a/imcsdk/imchandle.py
+++ b/imcsdk/imchandle.py
@@ -466,8 +466,7 @@ class ImcHandle(ImcSession):
                 self.__to_commit = {}
                 raise ImcException(response.error_code, response.error_descr)
 
-            for pair_ in response.out_config.child:
-                for out_mo in pair_.child:
-                    out_mo.sync_mo(mo_dict[out_mo.dn])
+            for out_mo in response.out_config.child:
+                out_mo.sync_mo(mo_dict[out_mo.dn])
 
         self.__to_commit = {}

--- a/imcsdk/imcmo.py
+++ b/imcsdk/imcmo.py
@@ -416,7 +416,8 @@ class ManagedObject(ImcBase):
             if prop in ManagedObject.__internal_prop or prop.startswith(
                     "_ManagedObject__"):
                 continue
-            mo.__dict__[prop] = prop_value
+            mo.__dict__[prop] = prop_value if prop != "status" else None
+        mo.mark_clean()
         return None
 
     def show_tree(self, level=0):


### PR DESCRIPTION
Fixed bug in commit method to sync_mo while doing config operation.
TestCode:
```
mo = CommSyslogClient(parent_mo_or_dn="sys/svc-ext/syslog", name="primary")
print mo
handle.set_mo(mo)
print mo
```

Output:
```Managed Object			:	CommSyslogClient
--------------
admin_action                    :None
admin_state                     :None
child_action                    :None
dn                              :sys/svc-ext/syslog/client-primary
hostname                        :None
name                            :primary
port                            :None
rn                              :client-primary
status                          :None



Managed Object			:	CommSyslogClient
--------------
admin_action                    :no-op
admin_state                     :disabled
child_action                    :None
dn                              :sys/svc-ext/syslog/client-primary
hostname                        :0.0.0.0
name                            :primary
port                            :514
rn                              :client-primary
status                          :modified
```
