### PR TITLE
Add Tetration adopter BU model prefix to valid model prefixes.

### DIFF
--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -467,7 +467,7 @@ class ImcSession(object):
         return False
 
     def _validate_model(self, model):
-        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX"]
+        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX", "TA-"]
         valid_models = ["R460-4640810", "C260-BASE-2646"]
 
         if model in valid_models:


### PR DESCRIPTION
Tetration server PIDs are:

* TA-CNODE-G1
* TA-SNODE-G1
* TA-BNODE-G1

