### PR TITLE
make compatible with rhel/centos 7 system python

### DIFF
--- a/imcsdk/imcdriver.py
+++ b/imcsdk/imcdriver.py
@@ -118,7 +118,7 @@ class TLSConnection(httplib.HTTPSConnection):
             self.sock = sock
             self._tunnel()
 
-        if sys.version_info >= (2, 7, 9):
+        if hasattr(ssl, 'SSLContext'):
             # Since python 2.7.9, tls 1.1 and 1.2 are supported via
             # SSLContext
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)


### PR DESCRIPTION
The support for PEP 476 (along with the required PEP 466 (Network
Security Enhancements for Python 2.7.x)) was added to python 2.7.5 and
first released as part of Red Hat Enterprise Linux 7.2.
https://access.redhat.com/articles/2039753
Version checks on rhel systems are not very relaible.