### PR TITLE
updated value for device.state (#155)

### DIFF
--- a/imcsdk/apis/server/boot.py
+++ b/imcsdk/apis/server/boot.py
@@ -205,7 +205,7 @@ def _add_boot_device(handle, parent_dn, boot_device):
                     if key not in ["order", "device-type", "name"]}
     device.set_prop_multiple(**device_props)
     if hasattr(device, "state"):
-        device.state = "enabled"
+        device.state = "Enabled"
     handle.add_mo(device, modify_present=True)
 
 


### PR DESCRIPTION
changed value 'enabled' to 'Enabled' to fix the error:

> [ErrorCode]: ERR-xml-parse-error[ErrorDescription]: XML PARSING ERROR: Element 'lsbootVMedia', attribute 'state': [facet 'enumeration'] The value 'enabled' is not an element of the set {'Disabled', 'Enabled'}. Element 'lsbootVMedia', attribute 'state': 'enabled' is not a valid value of the local atomic type.