### PR TITLE
imcsession: move valid_model_prefixes and valid_models to be ImcSession class variables

### DIFF
--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -30,6 +30,9 @@ class ImcSession(object):
     Parent class of ImcHandle, used internally by ImcHandle class.
     """
 
+    valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX"]
+    valid_models = ["R460-4640810", "C260-BASE-2646"]
+
     def __init__(self, ip, username, password, port=None, secure=None,
                  proxy=None, auto_refresh=False, force=False, timeout=None):
         self.__ip = ip
@@ -475,13 +478,10 @@ class ImcSession(object):
         return False
 
     def _validate_model(self, model):
-        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX"]
-        valid_models = ["R460-4640810", "C260-BASE-2646"]
-
-        if model in valid_models:
+        if model in ImcSession.valid_models:
             return True
 
-        for prefix in valid_model_prefixes:
+        for prefix in ImcSession.valid_model_prefixes:
             if model.startswith(prefix):
                 return True
 

--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -499,7 +499,7 @@ class ImcSession(object):
 
         if not response or response.error_code != 0 or \
                 len(response.out_configs.child) == 0:
-            self.logout()
+            self._logout()
             return False
 
         for element in response.out_configs.child:


### PR DESCRIPTION
After #126 was denied and the direction for imcsdk is to have adopter bu's fork the repo and maintain their own copy, it seems like this more work than is really needed.

I think it makes more sense to have the valid model prefixes and valid models to be class variables.  That way it is easier for adopter BU clients to update these lists as needed. 

For example

```
>>> from imcsdk.imcsession import ImcSession
>>> ImcSession.valid_model_prefixes.append("TA-")
```

Or:

```
>>> from imcsdk.imchandle import ImcHandle
>>> ImcHandle.valid_model_prefixes.append("TA-")
```

Edit:  Adding a minor fix where self.logout was called instead of self._logout, self.logout does not exist on ImcSession.