### PR TITLE
storage api: Fix exception raising

### DIFF
--- a/imcsdk/apis/server/storage.py
+++ b/imcsdk/apis/server/storage.py
@@ -50,7 +50,7 @@ def _flatten_list(drive_list):
     # [[1]] => [1]
     # [[1,2],[3,4]] => [1, 2, 3, 4]
     if not (isinstance(drive_list, list) and isinstance(drive_list[0], list)):
-        raise "drive_list needs a list of list(s). i.e [[1,2],[3,4]]"
+        raise ValueError("drive_list needs a list of list(s). i.e [[1,2],[3,4]]")
     dg_list = []
     for each in drive_list:
         for sub_each in each:
@@ -82,7 +82,7 @@ def _human_to_bytes(size_str):
                'PB': 5, 'EB': 6, 'ZB': 7, 'YB': 8}
     s = size_str.split()
     if s[1] not in convert:
-        raise "unknown size format" + size_str
+        raise ValueError("unknown size format - {0}".format(size_str))
     return int(s[0]) << (10 * convert[s[1]])
 
 
@@ -97,7 +97,7 @@ def _bytes_to_human(size, output_format=None):
     if output_format is None:
         output_format = unit[int(math.floor(math.log(size, 2))/10)]
     if output_format not in convert:
-        raise "unknown output format" + output_format
+        raise ValueError("unknown output format - {0}".format(output_format))
     return str(size >> (10 * convert[output_format])) + ' ' + output_format
 
 
@@ -140,7 +140,7 @@ def _raid_max_size_get(raid_level, total_size, min_size, span_depth):
             60: total_size - (span_depth * 2 * min_size)}
 
     if raid_level not in size:
-        raise "Unsupported Raid level" + str(raid_level)
+        raise ValueError("Unsupported Raid level - {0}".format(raid_level))
     return size[raid_level]
 
 


### PR DESCRIPTION
When using the apis/server/storage.py, an exception was not properly raised because it is a bare string and not an exception:

```
12/21/2017 12:43:00 AM ERROR root mjolnir.py:357 10.4.132.11 exception exceptions must be old-style classes or derived from BaseException, not str
Traceback (most recent call last):
  File "./mjolnir.py", line 355, in run
    task.run_install_task()
  File "./mjolnir.py", line 304, in run_install_task
    cimc.create_virtual_drives(self.raid)
  File "/home/tetter/tet-ops/scripts/ucs/imaging/cimcendpoint.py", line 1421, in create_virtual_drives
    create_virtual_drive(drive_name, raid_level, disk_str, disk_size)
  File "/home/tetter/tet-ops/scripts/ucs/imaging/cimcendpoint.py", line 1294, in create_virtual_drive
    self_encrypt=False, server_id=1)
  File "/home/tetter/tet-ops/scripts/ucs/imaging/imcsdk/apis/server/storage.py", line 265, in virtual_drive_create
    (vd_name_derive(raid_level, drive_group), vdn)[vdn is not None]
  File "/home/tetter/tet-ops/scripts/ucs/imaging/imcsdk/apis/server/storage.py", line 69, in vd_name_derive
    return "RAID" + str(raid_level) + "_" + _flatten_to_string(drive_list)
  File "/home/tetter/tet-ops/scripts/ucs/imaging/imcsdk/apis/server/storage.py", line 65, in _flatten_to_string
    return ''.join([''.join(str(x)) for x in _flatten_list(drive_list)])
  File "/home/tetter/tet-ops/scripts/ucs/imaging/imcsdk/apis/server/storage.py", line 53, in _flatten_list
    raise "drive_list needs a list of list(s). i.e [[1,2],[3,4]]"
TypeError: exceptions must be old-style classes or derived from BaseException, not str
```

Fix all `raise "string"` to raise ValueError exceptions.

Signed-off-by: Mike Timm <mtimm@tetrationanalytics.com>