### PR TITLE
make boot order api compatible with python3 using imcgenutils.iteritems

### DIFF
--- a/imcsdk/apis/server/boot.py
+++ b/imcsdk/apis/server/boot.py
@@ -18,6 +18,7 @@ This module provides APIs for bios related configuration like boot order
 
 import logging
 import imcsdk.imccoreutils as imccoreutils
+import imcsdk.imcgenutils as imcgenutils
 from imcsdk.mometa.lsboot.LsbootDevPrecision import LsbootDevPrecision
 
 log = logging.getLogger('imc')
@@ -137,7 +138,7 @@ def _is_boot_order_policy(dn):
 
 def _get_device_type(policy_type, in_device):
     if policy_type == "boot-order-policy":
-        for device_type, device_props in policy_device_dict.iteritems():
+        for device_type, device_props in imcgenutils.iteritems(policy_device_dict):
             if device_props["class_id"] == in_device._class_id and \
                     device_props["access"] == in_device.access:
                 return device_type
@@ -201,7 +202,7 @@ def _add_boot_device(handle, parent_dn, boot_device):
             (boot_device["device-type"], boot_device["name"]))
 
     device.order = boot_device["order"]
-    device_props = {key: value for key, value in boot_device.iteritems()
+    device_props = {key: value for key, value in imcgenutils.iteritems(boot_device)
                     if key not in ["order", "device-type", "name"]}
     device.set_prop_multiple(**device_props)
     if hasattr(device, "state"):
@@ -285,7 +286,7 @@ def boot_precision_configured_get(handle, server_id=1):
 
     class_to_name_dict = {
         value["class_id"]: key for key,
-        value in precision_device_dict.items()}
+        value in imcgenutils.iteritems(precision_device_dict)}
 
     server_dn = get_server_dn(handle, server_id)
     pmo = LsbootDevPrecision(parent_mo_or_dn=server_dn)

--- a/imcsdk/apis/v2/server/boot.py
+++ b/imcsdk/apis/v2/server/boot.py
@@ -18,6 +18,7 @@ This module provides APIs for bios related configuration like boot order
 
 import logging
 import imcsdk.imccoreutils as imccoreutils
+import imcsdk.imcgenutils as imcgenutils
 from imcsdk.mometa.lsboot.LsbootDevPrecision import LsbootDevPrecision
 
 log = logging.getLogger('imc')
@@ -141,7 +142,7 @@ def _is_boot_order_policy(dn):
 
 def _get_device_type(policy_type, in_device):
     if policy_type == "boot-order-policy":
-        for device_type, device_props in policy_device_dict.iteritems():
+        for device_type, device_props in imcgenutils.iteritems(policy_device_dict):
             if device_props["class_id"] == in_device._class_id and \
                     device_props["access"] == in_device.access:
                 return device_type
@@ -217,7 +218,7 @@ def _add_boot_device(handle, parent_mo_or_dn, boot_device):
             (boot_device["device-type"], boot_device["name"]))
 
     device.order = boot_device["order"]
-    device_props = {key: str(value) for key, value in boot_device.iteritems()
+    device_props = {key: str(value) for key, value in imcgenutils.iteritems(boot_device)
                     if key not in ["order", "device-type", "name"]}
     device.set_prop_multiple(**device_props)
     if hasattr(device, "state"):


### PR DESCRIPTION
I am utilizing the py3 compatibility function "imcgenutils.iteritems". I only tested with python3, but I can't imagine it would do anything unseemly in python2 given the usage elsewhere in imcsdk.