### PR TITLE
Add full_initialization admin action and DN1 as valid UCS 

### DIFF
--- a/imcsdk/apis/server/storage.py
+++ b/imcsdk/apis/server/storage.py
@@ -375,6 +375,37 @@ def virtual_drive_encryption_enable(handle, controller_type,
     handle.set_mo(vd)
     return handle.query_dn(vd.dn)
 
+def virtual_drive_start_full_initialize(handle, controller_type,
+                                        controller_slot, name, server_id=1):
+    """
+    Start full initialization on the virtual drive
+
+    Args:
+        handle (ImcHandle)
+        controller_type (str): Controller type
+                               'SAS'
+        controller_slot (str): Controller slot name/number
+                                "MEZZ","0"-"9", "HBA"
+        name (string): name of the virtual drive
+        server_id (int): server_id for UCS 3260 platform
+
+    Returns:
+        StorageVirtualDrive object
+
+    Examples:
+        virtual_drive_start_full_initialize(handle, 'SAS', 'HBA', 'test_vd')
+    """
+    from imcsdk.mometa.storage.StorageVirtualDrive import \
+        StorageVirtualDriveConsts
+    vd = vd_query_by_name(handle=handle,
+                          controller_type=controller_type,
+                          controller_slot=controller_slot,
+                          name=name,
+                          server_id=server_id)
+    vd.admin_action = StorageVirtualDriveConsts.ADMIN_ACTION_START_FULL_INITIALIZATION
+    handle.set_mo(vd)
+    return handle.query_dn(vd.dn)
+
 
 def virtual_drive_set_boot_drive(handle, controller_type, controller_slot, name, server_id=1):
     """

--- a/imcsdk/apis/server/storage.py
+++ b/imcsdk/apis/server/storage.py
@@ -406,6 +406,36 @@ def virtual_drive_start_full_initialize(handle, controller_type,
     handle.set_mo(vd)
     return handle.query_dn(vd.dn)
 
+def virtual_drive_cancel_initialization(handle, controller_type,
+                                        controller_slot, name, server_id=1):
+    """
+    Cancel full initialization on the virtual drive
+
+    Args:
+        handle (ImcHandle)
+        controller_type (str): Controller type
+                               'SAS'
+        controller_slot (str): Controller slot name/number
+                                "MEZZ","0"-"9", "HBA"
+        name (string): name of the virtual drive
+        server_id (int): server_id for UCS 3260 platform
+
+    Returns:
+        StorageVirtualDrive object
+
+    Examples:
+        virtual_drive_cancel_initialize(handle, 'SAS', 'HBA', 'test_vd')
+    """
+    from imcsdk.mometa.storage.StorageVirtualDrive import \
+        StorageVirtualDriveConsts
+    vd = vd_query_by_name(handle=handle,
+                          controller_type=controller_type,
+                          controller_slot=controller_slot,
+                          name=name,
+                          server_id=server_id)
+    vd.admin_action = StorageVirtualDriveConsts.ADMIN_ACTION_CANCEL_INITIALIZATION
+    handle.set_mo(vd)
+    return handle.query_dn(vd.dn)
 
 def virtual_drive_set_boot_drive(handle, controller_type, controller_slot, name, server_id=1):
     """

--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -475,7 +475,7 @@ class ImcSession(object):
         return False
 
     def _validate_model(self, model):
-        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX"]
+        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX", "DN1"]
         valid_models = ["R460-4640810", "C260-BASE-2646"]
 
         if model in valid_models:


### PR DESCRIPTION
Changes to add DN1 as a valid UCS model since the DNA-C appliances will be named DN1. Also added the admin action to start_full_initialization of VD. 