### PR TITLE
MANIFEST.in: Include requirements files in the source package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements.txt
+include test-requirements.txt
 
 recursive-include tests *
 recursive-include imcsdk/apis *


### PR DESCRIPTION
I was unable to install the source package from pypi because it was missing the requirements.txt and test-requirements.txt.  Adding them to the MANIFEST.in allows for them to be included and available on install if using the source package.

Signed-off-by: Mike Timm <mtimm@tetrationanalytics.com>