### PR TITLE
Support APIC models

### DIFF
--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -475,7 +475,7 @@ class ImcSession(object):
         return False
 
     def _validate_model(self, model):
-        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX"]
+        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX", "APIC"]
         valid_models = ["R460-4640810", "C260-BASE-2646"]
 
         if model in valid_models:


### PR DESCRIPTION
ACI APIC appliances are UCS 220 M3/M4 servers with a corresponding model name
of 'APIC-*'. Add 'APIC' to list of accepted model prefixes to allow access to
their IMC.

Signed-off-by: Robert Ayres <robayres@cisco.com>