### PR TITLE
Update validation support to include Ultra-M model numbers.

### DIFF
--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -475,7 +475,7 @@ class ImcSession(object):
         return False
 
     def _validate_model(self, model):
-        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX"]
+        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX", "ULTM"]
         valid_models = ["R460-4640810", "C260-BASE-2646"]
 
         if model in valid_models:


### PR DESCRIPTION
I've run the basic login against Ultra-M server and works.

This fixes: https://github.com/CiscoUcs/imcsdk/issues/195

Signed-off-by: Matt Seashore <mseashore@gmail.com>