### PR TITLE
utils: Add the ability to disable secure adapter update

### DIFF
--- a/imcsdk/utils/imcfirmwareinstall.py
+++ b/imcsdk/utils/imcfirmwareinstall.py
@@ -195,7 +195,7 @@ def firmware_huu_update_monitor(handle, secure_adapter_update=True,
                 log_progress("Firmware Upgrade is still running",
                              update_obj.overall_status)
                 current_status.append(update_obj.overall_status)
-                if (not secure_update and
+                if (not secure_adapter_update and
                     'HUU Discovery In Progress' in update_obj.overall_status):
                     # by design secure adapter update is enabled when
                     # the host reboots so if we want to allow adapter


### PR DESCRIPTION
Add the ability to disable secure adapter update.  

This has to be done as part of `firmware_huu_update_monitor` because when the host reboots secure adapter update is automatically enabled.  So as part of the monitor we can check for after the host has booted and set the secure adapter update to the value we desire.

Signed-off-by: Mike Timm <mtimm@tetrationanalytics.com>