### PR TITLE
Change default configured_boot_mode to None

### DIFF
--- a/imcsdk/apis/server/boot.py
+++ b/imcsdk/apis/server/boot.py
@@ -214,7 +214,7 @@ def boot_order_precision_set(
         handle,
         reboot_on_update="no",
         reapply="no",
-        configured_boot_mode="Legacy",
+        configured_boot_mode=None,
         boot_devices=[],
         server_id=1):
     """


### PR DESCRIPTION
When a user calls `boot_order_precision_set` and does not
specify a configure_boot_mode, then the boot mode should
not change. This patch changes the default value from
Legacy to None, so that the boot mode doesn't change if
the user does not specify it.