### PR TITLE
apis: Remove additional usages of iteritems

### DIFF
--- a/imcsdk/apis/server/boot.py
+++ b/imcsdk/apis/server/boot.py
@@ -18,7 +18,6 @@ This module provides APIs for bios related configuration like boot order
 
 import logging
 import imcsdk.imccoreutils as imccoreutils
-import imcsdk.imcgenutils as imcgenutils
 from imcsdk.mometa.lsboot.LsbootDevPrecision import LsbootDevPrecision
 
 log = logging.getLogger('imc')
@@ -138,7 +137,7 @@ def _is_boot_order_policy(dn):
 
 def _get_device_type(policy_type, in_device):
     if policy_type == "boot-order-policy":
-        for device_type, device_props in imcgenutils.iteritems(policy_device_dict):
+        for device_type, device_props in policy_device_dict.items():
             if device_props["class_id"] == in_device._class_id and \
                     device_props["access"] == in_device.access:
                 return device_type
@@ -202,7 +201,7 @@ def _add_boot_device(handle, parent_dn, boot_device):
             (boot_device["device-type"], boot_device["name"]))
 
     device.order = boot_device["order"]
-    device_props = {key: value for key, value in imcgenutils.iteritems(boot_device)
+    device_props = {key: value for key, value in boot_device.items()
                     if key not in ["order", "device-type", "name"]}
     device.set_prop_multiple(**device_props)
     if hasattr(device, "state"):
@@ -286,7 +285,7 @@ def boot_precision_configured_get(handle, server_id=1):
 
     class_to_name_dict = {
         value["class_id"]: key for key,
-        value in imcgenutils.iteritems(precision_device_dict)}
+        value in precision_device_dict.items()}
 
     server_dn = get_server_dn(handle, server_id)
     pmo = LsbootDevPrecision(parent_mo_or_dn=server_dn)

--- a/imcsdk/apis/v2/admin/snmp.py
+++ b/imcsdk/apis/v2/admin/snmp.py
@@ -82,7 +82,7 @@ def _reset(handle, local_mo, community, trap_community, engine_id_key):
     }
 
     reset = False
-    for prop, val in params.iteritems():
+    for prop, val in params.items():
         if getattr(mo, prop) == "" and input_params[prop] == "":
             log.debug("Reset %s." % prop)
             setattr(mo, prop, val)

--- a/imcsdk/apis/v2/server/bios.py
+++ b/imcsdk/apis/v2/server/bios.py
@@ -20,7 +20,6 @@ import logging
 import json
 import imcsdk.imccoreutils as imccoreutils
 from imcsdk.imccoreutils import is_platform_m4, is_platform_m5
-from imcsdk.imcgenutils import iteritems
 from imcsdk.imcexception import ImcOperationError, ImcException
 from imcsdk.apis.v2.utils import _is_valid_arg
 
@@ -360,7 +359,7 @@ def bios_tokens_set(handle, tokens={}, server_id=1):
     server_mos = _get_server_bios_mo_table(handle, dn=bios_mo.dn)
 
     # Prepare the filtered table i.e. send only those MOs that exist on the server
-    table = {k: v for k, v in iteritems(mo_table) if k in server_mos}
+    table = {k: v for k, v in mo_table.items() if k in server_mos}
 
     log.debug("Mo Table       Count: %s Values: %s" % (len(mo_table), mo_table))
     log.debug("Server Table   Count: %s Values: %s" % (len(server_mos), server_mos))
@@ -369,12 +368,12 @@ def bios_tokens_set(handle, tokens={}, server_id=1):
     processed_tokens = []
     # Separate the MOs which have only platform-default
     for mo_name, props in table.items():
-        non_default_props = {k: v for k, v in iteritems(props) if v != "platform-default"}
+        non_default_props = {k: v for k, v in props.items() if v != "platform-default"}
         # if there are no non-default props, it can be batched
         if len(non_default_props) == 0:
             # filter properties to only those applicable to the server
             server_mo_props = server_mos[mo_name]
-            filtered_props = {k: v for k, v in iteritems(props) if k in server_mo_props and server_mo_props[k]}
+            filtered_props = {k: v for k, v in props.items() if k in server_mo_props and server_mo_props[k]}
 
             if len(filtered_props) == 0:
                 log.debug("skipping token %s props: %s server_mo_props %s " % (mo_name, props, server_mo_props))
@@ -416,7 +415,7 @@ def bios_tokens_set(handle, tokens={}, server_id=1):
     for mo_name, props in table.items():
         d = {}
         server_mo_props = server_mos[mo_name]
-        filtered_props = {k: v for k, v in iteritems(props)
+        filtered_props = {k: v for k, v in props.items()
                           if k in server_mo_props and server_mo_props[k]}
 
         # REALLY DIRTY HACK!!
@@ -562,7 +561,7 @@ def _get_server_bios_mo_table(handle, dn):
     mo_table = {}
 
     for mo in mos:
-        props = {k: v for k, v in iteritems(mo.__dict__) if k.startswith('vp')}
+        props = {k: v for k, v in mo.__dict__.items() if k.startswith('vp')}
         mo_table[mo._class_id] = props
 
     return mo_table

--- a/imcsdk/apis/v2/server/boot.py
+++ b/imcsdk/apis/v2/server/boot.py
@@ -145,7 +145,7 @@ def _is_boot_order_policy(dn):
 
 def _get_device_type(policy_type, in_device):
     if policy_type == "boot-order-policy":
-        for device_type, device_props in policy_device_dict.iteritems():
+        for device_type, device_props in policy_device_dict.items():
             if device_props["class_id"] == in_device._class_id and \
                     device_props["access"] == in_device.access:
                 return device_type
@@ -633,7 +633,7 @@ def sanitize_input_from_intersight(handle, boot_devices):
         fix_bootloader_options(handle, each)
 
         # Check for any other properties which are "None" and pop them out
-        each = {k: v for k, v in each.iteritems() if v != "None"}
+        each = {k: v for k, v in each.items() if v != "None"}
 
         bd.append({k.lower(): v for k, v in each.items()})
     log.debug("##### Sanitized boot devices %s" % bd)

--- a/imcsdk/apis/v2/server/boot.py
+++ b/imcsdk/apis/v2/server/boot.py
@@ -20,7 +20,6 @@ import logging
 import re
 
 import imcsdk.imccoreutils as imccoreutils
-import imcsdk.imcgenutils as imcgenutils
 from imcsdk.imcexception import ImcOperationError, ImcOperationErrorDetail
 from imcsdk.mometa.lsboot.LsbootDevPrecision import LsbootDevPrecision
 
@@ -225,7 +224,7 @@ def _add_boot_device(handle, parent_mo_or_dn, boot_device):
 
     device.order = boot_device["order"]
     device_props = {key: str(value)
-                    for key, value in imcgenutils.iteritems(boot_device)
+                    for key, value in boot_device.items()
                     if key not in ["order", "device-type", "name"]}
 
     # For M4, mac_address will not be sent

--- a/imcsdk/apis/v2/storage/sdcard.py
+++ b/imcsdk/apis/v2/storage/sdcard.py
@@ -360,7 +360,7 @@ def _apply_config_card_action_util(handle, mos_dict, vds):
     api = "sd_card_virtual_drive_set"
     mos = []
     controller_dn = mos_dict['flexflash_controller'].dn
-    for vd_type, vd in vds.iteritems():
+    for vd_type, vd in vds.items():
         if not vd.vd_enable:
             continue
         # skip OS if only one slot is available in utility mode in M4
@@ -445,7 +445,7 @@ def _compare(expected_vds, existing_vds):
     if len(expected_vds) != len(existing_vds):
         exists = False
 
-    for exp_vd_type, exp_vd in expected_vds.iteritems():
+    for exp_vd_type, exp_vd in expected_vds.items():
         if exp_vd_type not in existing_vds:
             exists = False
             break
@@ -552,7 +552,7 @@ def _sd_card_config_set_m4(handle, expected_vds, existing_vds, mos_dict=None):
                     existing_os_vd.vd_mo.admin_action = "disable-vd"
                     handle.set_mo(existing_os_vd.vd_mo)
 
-            for expected_vd_type, expected_vd in expected_vds.iteritems():
+            for expected_vd_type, expected_vd in expected_vds.items():
                 existing_vd = existing_vds.get(expected_vd_type, None)
                 if existing_vd is None:
                     continue
@@ -633,7 +633,7 @@ def _sd_card_config_set_m5(handle, expected_vds, existing_vds, mos_dict):
             raise ImcOperationError("sd_card_config_set_m5",
                                     "Maximum two VD's can be enabled")
 
-    for expected_type, expected_vd in expected_vds.iteritems():
+    for expected_type, expected_vd in expected_vds.items():
         if expected_type == 'OS':
             continue
         existing_vd = existing_vds.get(expected_type, None)
@@ -789,7 +789,7 @@ def _get_expected_vds(virtual_drives={}):
 
 def _get_config_str(vds):
     config_str = ""
-    for vd_type, vd in vds.iteritems():
+    for vd_type, vd in vds.items():
         config_str += "%s: " % vd_type
         config_str += "{"
         config_str += str(vd)


### PR DESCRIPTION
`imcsdk.imcgenutils.iteritems` was removed but there are still several usages of it, converted them all over to `items()`.

Also change the usages of `iteritems()` to be just `items()` for python 3 compatibility.

Signed-off-by: Mike Timm <mtimm@tetrationanalytics.com>