### PR TITLE
ImcVersion: Only set patch version to z if it is a spin version

### DIFF
--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -103,13 +103,13 @@ class ImcVersion(object):
 
         # for spin builds 4.0(1S52), the patch version will be None
         # In this scenario assume the version to be highest patch z
-        if self.__patch is None:
+        if self.__spin is not None and self.__patch is None:
             self.__patch = 'z'
-        elif self.__patch.isdigit() and self.__mr.isdigit():
+        elif self.__patch is not None and self.__mr is not None and self.__patch.isdigit() and self.__mr.isdigit():
             log.debug("Interim version encountered: %s. MR version has been bumped up." % self.version)
             self.__mr = str(int(self.__mr) + 1)
             self.__patch = 'a'
-        elif self.__patch.isalpha() and self.__spin:
+        elif self.__patch is not None and self.__patch.isalpha() and self.__spin:
             log.debug("Interim version encountered: %s. patch version has been bumped up." % self.version)
             self.__patch = str(chr(ord(self.__patch)+1))
         return True

--- a/tests/unit_tests/common/test_imcversion.py
+++ b/tests/unit_tests/common/test_imcversion.py
@@ -89,9 +89,7 @@ def test_gt_different_major_version():
 
 
 def test_patch_versions():
-    # when we don't see a patch version we use z
-    # so 2.0(12) will be considerde as 2.0(12z)
     version1 = ImcVersion("2.0(12b)")
     version2 = ImcVersion("2.0(12)")
-    assert_equal((version1 > version2), False)
+    assert_equal((version1 > version2), True)
 


### PR DESCRIPTION
In previous imcsdk versions you could do this:

```
from imcsdk.imccoremeta import ImcVersion
Version404 = ImcVersion("4.0(4)")
```

And version comparisons against this would work as expected, any patch version of 4.0(4*) would basically match this version.  A >= comparison would return true for any patch version of 4.0(4*) and of course any major/minor version that was greater.

This change https://github.com/CiscoUcs/imcsdk/commit/c8a48e3679021eec23a2315c9be6564087df3467#diff-d3d8d1f12c7ff41f292412d345f9a8d1R106 causes this sort of version comparison to no longer be valid because it assumes if there is no patch version it must be a spin version and sets the patch version to z.  The change in this PR removes that assumption and only sets the patch version to `z` if a spin version is also detected.

Also this PR attempts to protect against doing isdigit against a NoneType in the other elif statements which allows the empty patch version to function again. 

Signed-off-by: Mike Timm <mtimm@tetrationanalytics.com>