### PR TITLE
imcfirmwareinstall: Update documentation for update_component

### DIFF
--- a/imcsdk/utils/imcfirmwareinstall.py
+++ b/imcsdk/utils/imcfirmwareinstall.py
@@ -41,7 +41,8 @@ def firmware_huu_update(handle, remote_share, share_type, remote_ip,
         username (string): username
         password (string): password
         update_component (string): component to be updated.
-            "all" for upgrading all components
+            "all" for upgrading all components but the hard drives
+            To upgrade all components and hdd's specify "all,hdd"
             Refer release notes for individual component names
         stop_on_error (string): "yes", "no"
         timeout (int): Timeout value. Range is 30-240 mins.


### PR DESCRIPTION
update_component allows for an "all" specification but this does not really mean all.  It means "all but hdd's" apparently.  This change updates the documentation for update_component to include info about how to get hard drives to update.