### PR TITLE
Allow to upgrade the CIMC of APIC as well

### DIFF
--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -472,7 +472,7 @@ class ImcSession(object):
         return False
 
     def _validate_model(self, model):
-        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX"]
+        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX", "APIC-SERVER-"]
         valid_models = ["R460-4640810", "C260-BASE-2646"]
 
         if model in valid_models:


### PR DESCRIPTION
Enhancing the IMCSDK to allow to upgrade also the CIMC of the UCS servers used in the APIC product. Currently the APIC-SERVER-* model is not assumed to be a valid CIMC, while it's.