### PR TITLE
Fix #219 remove Element.getchildren

### DIFF
--- a/imcsdk/imccore.py
+++ b/imcsdk/imccore.py
@@ -191,7 +191,7 @@ class BaseObject(ImcBase):
                 self.attr_set(imcgenutils.convert_to_python_var_name(attr_name),
                               str(attr_value))
 
-        child_elems = elem.getchildren()
+        child_elems = list(elem)
         if child_elems:
             for child_elem in child_elems:
                 if not Et.iselement(child_elem):

--- a/imcsdk/imcmethod.py
+++ b/imcsdk/imcmethod.py
@@ -142,7 +142,7 @@ class ExternalMethod(ImcBase):
                         ExternalMethod._external_method_attrs[attr_name],
                         str(attr_value))
 
-        child_elems = elem.getchildren()
+        child_elems = list(elem)
         if child_elems:
             for child_elem in child_elems:
                 if not ET.iselement(child_elem):

--- a/imcsdk/imcmo.py
+++ b/imcsdk/imcmo.py
@@ -413,7 +413,7 @@ class ManagedObject(ImcBase):
             self.__set_prop("rn", os.path.basename(self.dn), forced=True)
         self.mark_clean()
 
-        child_elems = elem.getchildren()
+        child_elems = list(elem)
         if child_elems:
             for child_elem in child_elems:
                 if not ET.iselement(child_elem):
@@ -637,7 +637,7 @@ class GenericMo(ImcBase):
             self.rn = os.path.basename(self.dn)
             self.__properties['rn'] = self.rn
 
-        children = elem.getchildren()
+        children = list(elem)
         if children:
             for child in children:
                 if not ET.iselement(child):


### PR DESCRIPTION
Signed-off-by: Alex King <alex@king.net.nz>

The tests show some errors, but hey, it works for me.
I use imcsdk from Debian stable, so I need python3.9 support.
Thanks,
Alex

======================================================================
ERROR: tests.server.test_adaptor.test_non_vntag_mode
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_adaptor.py", line 38, in test_non_vntag_mode
    adaptor_properties_set(handle, adaptor_slot=ADAPTOR_ID, fip_mode=True,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/adaptor.py", line 121, in adaptor_properties_set
    handle.set_mo(mo)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 467, in set_mo
    self._commit(timeout=timeout)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 557, in _commit
    raise ImcException(response.error_code, response.error_descr)
imcsdk.imcexception.ImcException: [ErrorCode]: 2003[ErrorDescription]: Operation failed. fip-mode enabled is incompatible with lldp disabled 

======================================================================
ERROR: tests.server.test_adaptor.test_vntag_mode
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_adaptor.py", line 64, in test_vntag_mode
    mo = adaptor_properties_get(handle, adaptor_slot=ADAPTOR_ID)
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/adaptor.py", line 70, in adaptor_properties_get
    return _get_mo(handle, dn=dn)
  File "/home/alex/temp/imcsdk/imcsdk/apis/utils.py", line 30, in _get_mo
    raise ImcOperationError("Get Managed Object for dn:%s" % dn,
imcsdk.imcexception.ImcOperationError: Get Managed Object for dn:sys/rack-unit-1/adaptor-MLOM/general failed. Error: Managed Object doesn't exist

======================================================================
ERROR: tests.server.test_adaptor.test_vntag_create_vnic
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_adaptor.py", line 71, in test_vntag_create_vnic
    vnic_mo = vnic_create(handle, adaptor_slot=ADAPTOR_ID, name="sdk-test-vnic",
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/adaptor.py", line 226, in vnic_create
    handle.add_mo(vnic, modify_present=True)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 443, in add_mo
    self._commit(timeout=timeout)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 557, in _commit
    raise ImcException(response.error_code, response.error_descr)
imcsdk.imcexception.ImcException: [ErrorCode]: 2006[ErrorDescription]: Host is powered OFF. Power ON host and try again.

======================================================================
ERROR: tests.server.test_adaptor.test_vntag_create_vhba
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_adaptor.py", line 86, in test_vntag_create_vhba
    vhba_mo = vhba_create(handle, adaptor_slot=ADAPTOR_ID, name="sdk-test-vhba",
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/adaptor.py", line 318, in vhba_create
    handle.add_mo(vhba_mo, modify_present=True)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 443, in add_mo
    self._commit(timeout=timeout)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 557, in _commit
    raise ImcException(response.error_code, response.error_descr)
imcsdk.imcexception.ImcException: [ErrorCode]: 2003[ErrorDescription]: Operation failed. cannot communicate with card (actions are not enabled) 7 (adapter)

======================================================================
ERROR: tests.server.test_adaptor.test_disable_vntag_mode
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_adaptor.py", line 106, in test_disable_vntag_mode
    mo = adaptor_properties_get(handle, adaptor_slot=ADAPTOR_ID)
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/adaptor.py", line 70, in adaptor_properties_get
    return _get_mo(handle, dn=dn)
  File "/home/alex/temp/imcsdk/imcsdk/apis/utils.py", line 30, in _get_mo
    raise ImcOperationError("Get Managed Object for dn:%s" % dn,
imcsdk.imcexception.ImcOperationError: Get Managed Object for dn:sys/rack-unit-1/adaptor-MLOM/general failed. Error: Managed Object doesn't exist

======================================================================
ERROR: tests.server.test_bios_profile.test_bios_profile_upload
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_bios_profile.py", line 57, in test_bios_profile_upload
    bios_profile_upload(handle, remote_server=REMOTE_SERVER,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/bios.py", line 122, in bios_profile_upload
    mo.set_prop_multiple(**params)
  File "/home/alex/temp/imcsdk/imcsdk/imcmo.py", line 233, in set_prop_multiple
    self.__set_prop(prop_name, kwargs[prop_name])
  File "/home/alex/temp/imcsdk/imcsdk/imcmo.py", line 193, in __set_prop
    raise ValueError("Invalid Value Exception - "
ValueError: Invalid Value Exception - [UploadBiosProfile]: Prop <remote_file>, Value<>. 

======================================================================
ERROR: tests.server.test_bios_profile.test_bios_profile_activate
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_bios_profile.py", line 66, in test_bios_profile_activate
    bios_profile_activate(handle, name='simple',
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/bios.py", line 183, in bios_profile_activate
    mo = _get_bios_profile(handle, name=name, server_id=server_id)
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/bios.py", line 46, in _get_bios_profile
    raise ImcOperationError("Get BiosProfile: %s " % name,
imcsdk.imcexception.ImcOperationError: Get BiosProfile: simple  failed. Error: Managed Object not found

======================================================================
ERROR: tests.server.test_bios_profile.test_bios_profile_generate_json
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_bios_profile.py", line 87, in test_bios_profile_generate_json
    output = bios_profile_generate_json(handle, name='simple')
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/bios.py", line 310, in bios_profile_generate_json
    mo = _get_bios_profile(handle, name=name, server_id=server_id)
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/bios.py", line 46, in _get_bios_profile
    raise ImcOperationError("Get BiosProfile: %s " % name,
imcsdk.imcexception.ImcOperationError: Get BiosProfile: simple  failed. Error: Managed Object not found

======================================================================
ERROR: tests.server.test_bios_profile.test_bios_profile_delete
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_bios_profile.py", line 99, in test_bios_profile_delete
    bios_profile_delete(handle, name='simple')
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/bios.py", line 217, in bios_profile_delete
    mo = _get_bios_profile(handle, name=name, server_id=server_id)
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/bios.py", line 46, in _get_bios_profile
    raise ImcOperationError("Get BiosProfile: %s " % name,
imcsdk.imcexception.ImcOperationError: Get BiosProfile: simple  failed. Error: Managed Object not found

======================================================================
ERROR: tests.server.test_storage.test_controller_encryption_enable
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 226, in test_controller_encryption_enable
    controller_encryption_enable(handle,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 529, in controller_encryption_enable
    enabled, mo = controller_encryption_exists(handle,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 607, in controller_encryption_exists
    mo = _get_controller(handle, controller_type, controller_slot, server_id)
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 187, in _get_controller
    raise ImcOperationError("Get Controller Type:%s Slot:%s" %
imcsdk.imcexception.ImcOperationError: Get Controller Type:SAS Slot:SLOT-HBA failed. Error: Managed Object not found

======================================================================
ERROR: tests.server.test_storage.test_controller_encryption_modify
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 237, in test_controller_encryption_modify
    controller_encryption_modify_security_key(
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 656, in controller_encryption_modify_security_key
    handle.set_mo(mo)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 467, in set_mo
    self._commit(timeout=timeout)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 557, in _commit
    raise ImcException(response.error_code, response.error_descr)
imcsdk.imcexception.ImcException: [ErrorCode]: 102[ErrorDescription]: Managed object (sys/rack-unit-1/board/storage-SAS-SLOT-HBA/ctr-self-encrypt) not found.

======================================================================
ERROR: tests.server.test_storage.test_controller_generated_keys
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 258, in test_controller_generated_keys
    controller_encryption_modify_security_key(
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 656, in controller_encryption_modify_security_key
    handle.set_mo(mo)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 467, in set_mo
    self._commit(timeout=timeout)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 557, in _commit
    raise ImcException(response.error_code, response.error_descr)
imcsdk.imcexception.ImcException: [ErrorCode]: ERR-xml-parse-error[ErrorDescription]: XML PARSING ERROR: Element 'selfEncryptStorageController', attribute 'securityKey': [facet 'minLength'] The value '' has a length of '0'; this underruns the allowed minimum length of '1'. 

======================================================================
ERROR: tests.server.test_storage.test_pd_jbod_mode_enable
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 280, in test_pd_jbod_mode_enable
    physical_drive_set_jbod_mode(handle,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 919, in physical_drive_set_jbod_mode
    raise ImcOperationError("Physical Drive: %s JBOD Mode Enable",
imcsdk.imcexception.ImcOperationError: Physical Drive: %s JBOD Mode Enable failed. Error: Controller JBOD mode is not enabled

======================================================================
ERROR: tests.server.test_storage.test_pd_encryption_enable
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 300, in test_pd_encryption_enable
    is_pd_capable = is_physical_drive_encryption_capable(
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 855, in is_physical_drive_encryption_capable
    raise ImcOperationError("Get Physical Drive:%s" % drive_slot,
imcsdk.imcexception.ImcOperationError: Get Physical Drive:4 failed. Error: Managed Object not found

======================================================================
ERROR: tests.server.test_storage.test_pd_set_unconfigured_good
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 323, in test_pd_set_unconfigured_good
    physical_drive_set_unconfigured_good(
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 958, in physical_drive_set_unconfigured_good
    return _physical_drive_action_set(
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 819, in _physical_drive_action_set
    raise ImcOperationError("Get Physical Drive",
imcsdk.imcexception.ImcOperationError: Get Physical Drive failed. Error: Managed Object not found

======================================================================
ERROR: tests.server.test_storage.test_vd_create_delete_with_encryption
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 366, in test_vd_create_delete_with_encryption
    virtual_drive_create(
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 267, in virtual_drive_create
    params["size"] = (_vd_max_size_get(handle=handle,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 163, in _vd_max_size_get
    sizes = _pd_sizes_get(handle=handle,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 117, in _pd_sizes_get
    sizes.append(_human_to_bytes(dmo.coerced_size))
AttributeError: 'NoneType' object has no attribute 'coerced_size'

======================================================================
ERROR: tests.server.test_storage.test_controller_encryption_disable
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_storage.py", line 393, in test_controller_encryption_disable
    controller_encryption_disable(handle,
  File "/home/alex/temp/imcsdk/imcsdk/apis/server/storage.py", line 580, in controller_encryption_disable
    handle.set_mo(mo)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 467, in set_mo
    self._commit(timeout=timeout)
  File "/home/alex/temp/imcsdk/imcsdk/imchandle.py", line 557, in _commit
    raise ImcException(response.error_code, response.error_descr)
imcsdk.imcexception.ImcException: [ErrorCode]: 102[ErrorDescription]: Managed object (sys/rack-unit-1/board/storage-SAS-SLOT-HBA/ctr-self-encrypt) not found.

======================================================================
FAIL: tests.common.test_imctoxml.test_001_mo_heirarchy_to_xml
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/common/test_imctoxml.py", line 56, in test_001_mo_heirarchy_to_xml
    assert_equal(xc.to_xml_str(obj.to_xml()), expected)
AssertionError: b'<me[48 chars]ent" id="1" mostRecent="no" rn="1" suspect="no[581 chars]st1>' != b'<me[48 chars]ent" dn="sys/chassis-1/blade-2/board/memarray-[581 chars]st1>'

======================================================================
FAIL: tests.server.test_bios_profile.test_bios_profile_exists
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_bios_profile.py", line 77, in test_bios_profile_exists
    assert_equal(match, True)
AssertionError: False != True

======================================================================
FAIL: tests.server.test_bios_tokens.test_bios_tokens_exist
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_bios_tokens.py", line 69, in test_bios_tokens_exist
    assert_equal(match, False)
AssertionError: True != False
-------------------- >> begin captured logging << --------------------
imc: WARNING: Token not found: BaudRate Platform: classic
imc: WARNING: Token not found: IntelVTDATSSupport Platform: classic
imc: WARNING: Token not found: ConsoleRedirection Platform: classic
imc: WARNING: Token not found: FlowControl Platform: classic
--------------------- >> end captured logging << ---------------------

======================================================================
FAIL: tests.server.test_power.test_power_cycle_server
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/alex/temp/imcsdk/tests/server/test_power.py", line 50, in test_power_cycle_server
    assert_equal(server_power_state_get(handle),
AssertionError: 'off' != 'on'
- off
+ on


----------------------------------------------------------------------
Ran 195 tests in 1468.154s

FAILED (errors=17, failures=4)
