### PR TITLE
Support for Python3.11

### DIFF
--- a/imcsdk/imccoreutils.py
+++ b/imcsdk/imccoreutils.py
@@ -18,6 +18,7 @@ This module contains the ImcSdk Core utilities.
 import os
 import re
 import logging
+import sys
 
 from . import imcgenutils
 from . import mometa
@@ -76,7 +77,12 @@ def get_imc_obj(class_id, elem, mo_obj=None):
         return imcmethod.ExternalMethod(class_id)
     elif class_id in MO_CLASS_ID:
         mo_class = load_class(class_id)
-        mo_class_params = inspect.getfullargspec(mo_class.__init__)[0][2:]
+        if sys.version_info > (3, 0):
+            # Python 3 code in this block
+            mo_class_params = inspect.getfullargspec(mo_class.__init__)[0][2:]
+        else:
+            # Python 2 code in this block
+            mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
         mo_class_param_dict = {}
         for param in mo_class_params:
             mo_class_param_dict[param] = None

--- a/imcsdk/imccoreutils.py
+++ b/imcsdk/imccoreutils.py
@@ -76,7 +76,7 @@ def get_imc_obj(class_id, elem, mo_obj=None):
         return imcmethod.ExternalMethod(class_id)
     elif class_id in MO_CLASS_ID:
         mo_class = load_class(class_id)
-        mo_class_params = inspect.getargspec(mo_class.__init__)[0][2:]
+        mo_class_params = inspect.getfullargspec(mo_class.__init__)[0][2:]
         mo_class_param_dict = {}
         for param in mo_class_params:
             mo_class_param_dict[param] = None


### PR DESCRIPTION
Method "getargspec()" is deprecated since python3.0. Using backward compatible "getfullargspec()" instead.