### PR TITLE
imccoremeta: Update ImcVersion to match the new major.minor(mr.patch) release numbering

### DIFF
--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -131,7 +131,7 @@ class ImcVersion(object):
               and self.__mr is not None
               and self.__patch.isdigit()
               and self.__mr.isdigit()
-              and len(self.__patch) > 6):
+              and len(self.__patch) < 6):
             log.debug("Interim version encountered: %s. MR version has been bumped up." % self.version)
             self.__mr = str(int(self.__mr) + 1)
             self.__patch = 'a'

--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -48,21 +48,11 @@ class ImcVersion(object):
         self.__patch = None
         self.__spin = None
 
-        # Matches major.minor(mr.patch), example 4.3(2.240002), new style of release numbering
+        # Matches major.minor(mr.patch), example 4.3(2.4) as well as 4.3(2.240002)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<patch>(([0-9]){6}))\)$")
-        match_obj = re.match(match_pattern, version)
-        if self._set_versions(match_obj):
-            return
-
-
-        # Matches major.minor(mr.patch), example 4.3(2.4)
-        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
-                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
-                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
-                                   "(?P<patch>(([0-9])|([1-9][0-9]{0,4})))\)$")
+                                   "(?P<patch>(([0-9])|([1-9][0-9]{0,5})))\)$")
         match_obj = re.match(match_pattern, version)
         if self._set_versions(match_obj):
             return

--- a/imcsdk/imccoremeta.py
+++ b/imcsdk/imccoremeta.py
@@ -48,6 +48,17 @@ class ImcVersion(object):
         self.__patch = None
         self.__spin = None
 
+        # Matches major.minor(mr.patch), example 4.3(2.240002), new style of release numbering
+        match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
+                                   "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
+                                   "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
+                                   "(?P<patch>(([0-9]){6}))\)$")
+        match_obj = re.match(match_pattern, version)
+        if self._set_versions(match_obj):
+            return
+
+
+        # Matches major.minor(mr.patch), example 4.3(2.4)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\."
@@ -56,6 +67,7 @@ class ImcVersion(object):
         if self._set_versions(match_obj):
             return
 
+        # Matches major.minor(mrpatch), example 4.3(2a)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))"
@@ -64,6 +76,7 @@ class ImcVersion(object):
         if self._set_versions(match_obj):
             return
 
+        # Matches major.minor(mr), example 4.3(2)
         match_pattern = re.compile("^(?P<major>[1-9][0-9]{0,2})\."
                                    "(?P<minor>(([0-9])|([1-9][0-9]{0,1})))\("
                                    "(?P<mr>(([0-9])|([1-9][0-9]{0,2})))\)$")
@@ -124,7 +137,11 @@ class ImcVersion(object):
         # In this scenario assume the version to be highest patch z
         if self.__spin is not None and self.__patch is None:
             self.__patch = 'z'
-        elif self.__patch is not None and self.__mr is not None and self.__patch.isdigit() and self.__mr.isdigit():
+        elif (self.__patch is not None
+              and self.__mr is not None
+              and self.__patch.isdigit()
+              and self.__mr.isdigit()
+              and len(self.__patch) > 6):
             log.debug("Interim version encountered: %s. MR version has been bumped up." % self.version)
             self.__mr = str(int(self.__mr) + 1)
             self.__patch = 'a'


### PR DESCRIPTION
As of the 4.3 release the release number has changed to a `major.minor(mr.patch)` numbering where the patch is a 6 digit number representing the 2 digit year and a rebuild number.  For example: `4.3(2.240072)`.  See https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/release/notes/b_release-notes-for-cisco-ucs-rack-server-software-release-4_3_2.html#cisco-imc-release-number-and-.iso-image-names for more details.  

This change updates `ImcVersion` to match the new release numbering putting the 6 digit number into the patch property.  This allows version comparisons of the new release numbers.