### PR TITLE
imcsession: add support for the FMC, ND-NODE, and SNS model prefixes

### DIFF
--- a/imcsdk/imcsession.py
+++ b/imcsdk/imcsession.py
@@ -504,7 +504,7 @@ class ImcSession(object):
         return False
 
     def _validate_model(self, model):
-        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX", "APIC-SERVER-", "DN1", "DN2", "DN3", "ULTM"]
+        valid_model_prefixes = ["UCSC", "UCS-E", "UCSS", "HX", "APIC-SERVER-", "DN1", "DN2", "DN3", "FMC", "ND-NODE-", "SNS", "ULTM"]
         valid_models = ["R460-4640810", "C260-BASE-2646"]
 
         if model in valid_models:


### PR DESCRIPTION
This change enables using the imcsdk with:
* Cisco UCS C220 M6 servers with a PID that starts with "SNS", such as SNS-3795-K9
* Cisco UCS C225 M6 servers with a PID that starts with "ND-NODE", such as ND-NODE-L4

Tested and confirmed working.